### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 language: python
 python:
    - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
    - "3.4"
    - "3.5"
    - "3.6"
+before_install:
+  - pip install -U pip setuptools
 install:
   - make setup_dev
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+   - "2.7"
+   - "3.3"
+   - "3.4"
+   - "3.5"
+   - "3.6"
+install:
+  - make setup_dev
+script:
+  - make test
+notifications:
+  email: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 python_files := find . -path '*/.*' -prune -o -name '*.py' -print0
+python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
+python_version_major := $(word 1,${python_version_full})
 
 all: test
 
@@ -13,7 +15,10 @@ autopep8:
 lint:
 	@echo 'Linting...'
 	@pylint --rcfile=pylintrc shopify_python tests.shopify_python
-	@mypy shopify_python tests/shopify_python --ignore-missing-imports
+	@if [ "$(python_version_major)" == "3" ]; then \
+		echo 'Checking type annotations...'; \
+		mypy --py2 shopify_python tests/shopify_python --ignore-missing-imports; \
+	fi
 
 autolint: autopep8 lint
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 python_files := find . -path '*/.*' -prune -o -name '*.py' -print0
 python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
 python_version_major := $(word 1,${python_version_full})

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,10 @@
 import re
 
 try:
-    from setuptools import setup
+    import setuptools as setuplib
 except:
-    from distutils.core import setup
+    import distutils.core as setuplib
+
 
 with open('shopify_python/__init__.py', 'r') as fd:
     version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
@@ -15,7 +16,7 @@ with open('shopify_python/__init__.py', 'r') as fd:
 if not version:
     raise RuntimeError('Cannot find version information')
 
-setup(
+setuplib.setup(
     name='shopify_python',
     version=version,
     description='Python Standards Library for Shopify',

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,23 @@
+#!/usr/bin/env python
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+import re
+
 try:
     from setuptools import setup
 except:
     from distutils.core import setup
 
+with open('shopify_python/__init__.py', 'r') as fd:
+    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
+                        fd.read(), re.MULTILINE).group(1)
+
+if not version:
+    raise RuntimeError('Cannot find version information')
+
 setup(
     name='shopify_python',
-    version='0.1',
+    version=version,
     description='Python Standards Library for Shopify',
     url='http://github.com/shopify/shopify_python',
     author='Shopify Data Acceleration',
@@ -31,7 +43,7 @@ setup(
             'autopep8',
             'pytest',
             'pytest-randomly',
-            'mypy',
+            'mypy; python_version > "3.3"',
         ]
     }
 )

--- a/tests/shopify_python/test_package.py
+++ b/tests/shopify_python/test_package.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
-from __future__ import unicode_literals
+import shopify_python
 
-__version__ = '0.0.0'
+
+def test_version():
+    assert shopify_python.__version__


### PR DESCRIPTION
This PR adds support for Travis CI including:
  - Python 2.7, 3.3, 3.4, 3.5, and 3.6
  - Pylint on all Python versions
  - Mypy Python 2-compatible type annotation checking for Python 3.x only

To accomplish this, a modern requirement specifier was used in `setup.py`'s`extras_require` which necessitated upgrading `setuptools` on Travis CI.