### PR TITLE
Follow semantic versioning 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ exceptions:
   - Prefix module-private functions and variables with a single underscore.
 - Multi-line docstrings: The first line of text (summary line) appears on the same line as the opening three double-quotes.
 
+## Versioning
+
+Project version numbering follows [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html), i.e.
+
+> Given a version number MAJOR.MINOR.PATCH, increment the:
+> 
+> MAJOR version when you make incompatible API changes,
+> MINOR version when you add functionality in a backwards-compatible manner, and
+> PATCH version when you make backwards-compatible bug fixes.
+>
+> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+
 ## Testing
 
 All committed code requires quality tests that provide ample code coverage. Functionality that is not covered by tests


### PR DESCRIPTION
For projects, including those one, we should follow a standard version numbering scheme. For simplicity, let's use [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html).