### PR TITLE
Exception false negative

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -117,7 +117,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
     def __dont_use_archaic_raise_syntax(self, node):  # type: (astroid.Raise) -> None
         """Don't use the two-argument form of raise or the string raise"""
         children = list(node.get_children())
-        if len(children) > 1:
+        if len(children) > 1 and not isinstance(children[1], astroid.Name):
             self.add_message('two-arg-exception', node=node)
         elif len(children) == 1 and isinstance(children[0], six.string_types):
             self.add_message('string-exception', node=node)

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -68,6 +68,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         with self.assertAddsMessages(message):
             self.walk(root)
 
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="Tests code that is Python 2 incompatible")
     def test_using_reraise_passes(self):
         root = astroid.builder.parse("""
         try:

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -68,6 +68,16 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         with self.assertAddsMessages(message):
             self.walk(root)
 
+    def test_using_reraise_passes(self):
+        root = astroid.builder.parse("""
+        try:
+            x = 1
+        except Exception as exc:
+            raise MyException from exc
+        """)
+        with self.assertNoMessages():
+            self.walk(root)
+
     def test_catch_standard_error_fails(self):
         root = astroid.builder.parse("""
         try:


### PR DESCRIPTION
This syntax for re-raising exceptions with context is acceptable, and shouldn't raise a linter error.

@cfournie 