### PR TITLE
Fix import-module-only check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setuplib.setup(
     install_requires=[
         'pylint==1.6.5',
         'six>=1.10.0',
+        'typing>=3.5.3.0',
     ],
     extras_require={
         'dev': [

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -6,7 +6,7 @@ from pylint import lint
 from shopify_python import google_styleguide
 
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -1,4 +1,4 @@
-import sys
+import typing  # pylint: disable=unused-import
 
 import astroid  # pylint: disable=unused-import
 import six
@@ -6,12 +6,6 @@ import six
 from pylint import checkers
 from pylint import interfaces
 from pylint import lint  # pylint: disable=unused-import
-
-
-if sys.version_info >= (3, 4):
-    import importlib.util  # pylint: disable=no-name-in-module,import-error
-else:
-    import importlib
 
 
 def register_checkers(linter):  # type: (lint.PyLinter) -> None
@@ -33,12 +27,12 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
     name = 'google-styleguide-checker'
 
     msgs = {
-        'C2601': ('Imported an object that is not a package or module',
+        'C2601': ('%(child)s is not a module or cannot be imported',
                   'import-modules-only',
-                  'Use imports for packages and modules only'),
-        'C2602': ('Imported using a partial path',
+                  'Install %(child)s or only import packages or modules from it'),
+        'C2602': ('%(module)s imported relatively',
                   'import-full-path',
-                  'Import each module using the full pathname location of the module.'),
+                  'Import %(module)s using the absolute name.'),
         'C2603': ('Variable declared at the module level (i.e. global)',
                   'global-variable',
                   'Avoid global variables in favor of class variables'),
@@ -66,39 +60,36 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
     def visit_raise(self, node):  # type: (astroid.Raise) -> None
         self.__dont_use_archaic_raise_syntax(node)
 
+    @staticmethod
+    def __get_module_names(node):  # type: (astroid.ImportFrom) -> typing.Generator[str, None, None]
+        for name in node.names:
+            name, _ = name
+            yield '.'.join((node.modname, name))  # Rearrange "from x import y" as "import x.y"
+
     def __import_modules_only(self, node):  # type: (astroid.ImportFrom) -> None
         """Use imports for packages and modules only."""
-
-        if hasattr(self.linter, 'config') and 'import-modules-only' in self.linter.config.disable:
-            return  # Skip if disable to avoid side-effects from importing modules
-
-        def can_import(module_name):
-            if sys.version_info >= (3, 4):
-                try:
-                    return bool(importlib.util.find_spec(module_name))
-                except AttributeError:
-                    return False  # Occurs when a module doesn't exist
-                except ImportError:
-                    return False  # Occurs when a module encounters an error during import
-            else:
-                try:
-                    importlib.import_module(module_name)
-                    return True
-                except ImportError:
-                    return False  # Occurs when a module doesn't exist or on error during import
-
         if not node.level and node.modname != '__future__':
-            for name in node.names:
-                name, _ = name
-                parent_module = node.modname
-                child_module = '.'.join((node.modname, name))  # Rearrange "from x import y" as "import x.y"
-                if can_import(parent_module) and not can_import(child_module):
-                    self.add_message('import-modules-only', node=node)
+
+            # Walk up the parents until we hit one that can import a module (e.g. a module)
+            parent = node.parent
+            while not hasattr(parent, 'import_module'):
+                parent = parent.parent
+
+            # Warn on each imported name (yi) in "from x import y1, y2, y3"
+            for child_module in self.__get_module_names(node):
+                try:
+                    parent.import_module(child_module)
+                except astroid.exceptions.AstroidBuildingException as building_exception:
+                    if str(building_exception).startswith('Unable to load module'):
+                        self.add_message('import-modules-only', node=node, args={'child': child_module})
+                    else:
+                        raise
 
     def __import_full_path_only(self, node):  # type: (astroid.ImportFrom) -> None
         """Import each module using the full pathname location of the module."""
         if node.level:
-            self.add_message('import-full-path', node=node)
+            for child_module in self.__get_module_names(node):
+                self.add_message('import-full-path', node=node, args={'module': child_module})
 
     def __avoid_global_variables(self, node):  # type: (astroid.Assign) -> None
         """Avoid global variables."""

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -48,12 +48,12 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
     }
 
     options = (
-         ('ignore-module-import-only', {
-             'default': ('__future__',),
-             'type': 'csv',
-             'help': 'List of top-level module names separated by comma.'}),
+        ('ignore-module-import-only', {
+            'default': ('__future__',),
+            'type': 'csv',
+            'help': 'List of top-level module names separated by comma.'}),
     )
-    
+
     def visit_assign(self, node):  # type: (astroid.Assign) -> None
         self.__avoid_global_variables(node)
 
@@ -75,8 +75,8 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
     def __import_modules_only(self, node):  # type: (astroid.ImportFrom) -> None
         """Use imports for packages and modules only."""
-        matches_ignored_module = any(
-            (node.modname.startswith(module_name) for module_name in self.config.ignore_module_import_only))
+        matches_ignored_module = any((node.modname.startswith(module_name) for module_name in
+                                      self.config.ignore_module_import_only))  # pylint: disable=no-member
         if not node.level and not matches_ignored_module:
             # Walk up the parents until we hit one that can import a module (e.g. a module)
             parent = node.parent

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -47,6 +47,13 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   "Don't catch StandardError"),
     }
 
+    options = (
+         ('ignore-module-import-only', {
+             'default': ('__future__',),
+             'type': 'csv',
+             'help': 'List of top-level module names separated by comma.'}),
+    )
+    
     def visit_assign(self, node):  # type: (astroid.Assign) -> None
         self.__avoid_global_variables(node)
 
@@ -68,8 +75,9 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
     def __import_modules_only(self, node):  # type: (astroid.ImportFrom) -> None
         """Use imports for packages and modules only."""
-        if not node.level and node.modname != '__future__':
-
+        matches_ignored_module = any(
+            (node.modname.startswith(module_name) for module_name in self.config.ignore_module_import_only))
+        if not node.level and not matches_ignored_module:
             # Walk up the parents until we hit one that can import a module (e.g. a module)
             parent = node.parent
             while not hasattr(parent, 'import_module'):

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -36,7 +36,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
 
     def test_importing_modules_passes(self):
         root = astroid.builder.parse("""
-        from __future__ import unicode_literals
+        from __future__ import unicode_literals  # Test default option to ignore __future__
         from xml import dom
         from xml import sax
         def fnc():


### PR DESCRIPTION
### Problem
On a Python 3.5 project, when applying the `import-modules-only` rule its call to `importlib.util.find_spec` was returning `None` for modules (but not packages) when linting, but their parent packages succeeded, causing them to look like they were unimportable children of a module (i.e. probably a function/class).

### Solution
This PR:
  - Alters how import checks are perfomed; instead of relying upon the various implementations of `importlib` available this borrows functionality used by the [pylint F0401 "Unable to import %s" ](https://github.com/PyCQA/pylint/blob/7df8caaa3e1995018417ac2fd87afd89be6945ba/pylint/checkers/imports.py#L603) check to [search for and parse the AST of the file described by the import](https://github.com/PyCQA/astroid/blob/ac3e82e9bd8678086325a71a927a06bbc43d415e/astroid/manager.py#L104) (this still requires that the file be available to import but it no longer performs an import);
  - Implements an option (`ignore-module-import-only`) to allow users to ignore certain top-level modules during the `import-modules-only` check;
  - `import-modules-only` and `import-full-path` rules now indicate the name of the child module that was expected to exist. 