### PR TITLE
[WIP] Allow some forms of class definitions as global vars

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -105,6 +105,19 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         # Is this an assignment happening within a module? If so report on each assignment name
         # whether its in a tuple or not
         if isinstance(node.parent, astroid.Module):
+
+            # Is this an allowable assignment
+            fnc_node = None
+            if isinstance(node.value, astroid.Call):
+                fnc_node = node.value.func
+            elif isinstance(node.value, astroid.Subscript):
+                fnc_node = node.value.value
+            if fnc_node and '{module}.{function}'.format(
+                    module=fnc_node.expr.name,
+                    function=fnc_node.attrname) in ('collections.namedtuple', 'typing.Dict'):
+                return
+
+            # Report on each assignment name
             for target in node.targets:
                 if hasattr(target, 'elts'):
                     for elt in target.elts:

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -57,6 +57,24 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         ):
             self.walk(root)
 
+    def test_global_var_namedtuple(self):
+        root = astroid.builder.parse("""
+        import collections
+        Point = collections.namedtuple('Point', ['x', 'y'])
+        TaskStateSerialization = typing.Dict[str, typing.Any]
+        """)
+        with self.assertNoMessages():
+            self.walk(root)
+
+    @pytest.mark.skipif(sys.version_info < (3, 0), reason="Tests code that is Python 2 incompatible")
+    def test_global_var_typing_passes(self):
+        root = astroid.builder.parse("""
+        import typing
+        TaskStateSerialization = typing.Dict[str, typing.Any]
+        """)
+        with self.assertNoMessages():
+            self.walk(root)
+
     @pytest.mark.skipif(sys.version_info >= (3, 0), reason="Tests code that is Python 3 incompatible")
     def test_using_archaic_raise_fails(self):
         root = astroid.builder.parse("""


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify_python/issues/9

TODO:
  - Make configurable
  - Handle arbitrarily long module names