### PR TITLE
Add try/except/finally complexity rules

### DIFF
--- a/shopify_python/ast.py
+++ b/shopify_python/ast.py
@@ -1,0 +1,8 @@
+import astroid  # pylint: disable=unused-import
+
+
+def count_tree_size(node):  # type: (astroid.NodeNG) -> int
+    size = 1
+    for child in node.get_children():
+        size += count_tree_size(child)
+    return size

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -66,15 +66,15 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
             'type': 'csv',
             'help': 'List of top-level module names separated by comma.'}),
         ('max-try-nodes', {
-            'default': 20,
+            'default': 25,
             'type': 'int',
             'help': 'Number of AST nodes permitted in a try-block'}),
         ('max-except-nodes', {
-            'default': 30,
+            'default': 23,
             'type': 'int',
             'help': 'Number of AST nodes permitted in an except-block'}),
         ('max-finally-nodes', {
-            'default': 10,
+            'default': 13,
             'type': 'int',
             'help': 'Number of AST nodes permitted in a finally-block'}),
     )
@@ -116,11 +116,12 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
             # Warn on each imported name (yi) in "from x import y1, y2, y3"
             for child_module in self.__get_module_names(node):
+                args = {'child': child_module}
                 try:
                     parent.import_module(child_module)
                 except astroid.exceptions.AstroidBuildingException as building_exception:
                     if str(building_exception).startswith('Unable to load module'):
-                        self.add_message('import-modules-only', node=node, args={'child': child_module})
+                        self.add_message('import-modules-only', node=node, args=args)
                     else:
                         raise
 

--- a/tests/shopify_python/test_ast.py
+++ b/tests/shopify_python/test_ast.py
@@ -1,0 +1,11 @@
+import astroid
+
+from shopify_python import ast
+
+
+def test_count_tree_size():
+    root = astroid.builder.parse("""
+    def test(x, y):
+        return x * y if x > 5 else 0
+    """)
+    assert ast.count_tree_size(root) == 14

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -118,7 +118,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         root = astroid.builder.parse("""
         try:
             a = [x for x in range(0, 10) if x < 5]
-            a = sum((x * 2 for x in a))
+            a = sum((x * 2 for x in a)) + (a ** 2)
         except AssertionError as assert_error:
             if set(assert_error).startswith('Division by zero'):
                 raise MyException(assert_error, [x for x in range(0, 10) if x < 5])
@@ -131,7 +131,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         """)
         with self.assertAddsMessages(
             pylint.testutils.Message('finally-too-long', node=root.body[0], args={'found': 24}),
-            pylint.testutils.Message('try-too-long', node=root.body[0].body[0], args={'found': 24}),
+            pylint.testutils.Message('try-too-long', node=root.body[0].body[0], args={'found': 28}),
             pylint.testutils.Message('except-too-long', node=root.body[0].body[0].handlers[0],
                                      args={'found': 39}),
         ):

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -129,10 +129,11 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
             a = [x for x in range(0, 10) if x < 5]
             a = sum((x * 2 for x in a))
         """)
+        try_finally = root.body[0]
+        try_except = try_finally.body[0]
         with self.assertAddsMessages(
-            pylint.testutils.Message('finally-too-long', node=root.body[0], args={'found': 24}),
-            pylint.testutils.Message('try-too-long', node=root.body[0].body[0], args={'found': 28}),
-            pylint.testutils.Message('except-too-long', node=root.body[0].body[0].handlers[0],
-                                     args={'found': 39}),
+            pylint.testutils.Message('finally-too-long', node=try_finally, args={'found': 24}),
+            pylint.testutils.Message('try-too-long', node=try_except, args={'found': 28}),
+            pylint.testutils.Message('except-too-long', node=try_except.handlers[0], args={'found': 39}),
         ):
             self.walk(root)


### PR DESCRIPTION
This PR tries to measure the complexity of `try`/`except`/`finally` blocks in terms of the number of AST nodes within the body of each statement. The goal of these rules is to encourage less code (not simply measured in lines) within these sections.

> The larger the body of the try, the more likely that an exception will be raised by a line of code that you didn't expect to raise an exception. In those cases, the try/except block hides a real error. 

– Google Python Styleguide

Running this on a large codebase we get no parse errors and by setting the max length to zero we also get some statistics on body tree sizes in nodes:

| 	| Try	| Except	| Finally
|----|------|-----------|--------
| Count	| 122	| 126	| 12
| 90th precentile	| 40.8	| 33	| 15.7
| 80th precentile	| 24.8	| 23	| 12.8
| 70th precentile	| 18	| 17	| 12
| Min	| 1	| 2	| 4
| Max	| 104	| 111	| 29
| Mean	| 17	| 16	| 11
| Median	| 10	| 11	| 10

Assuming that the 80% of this large project's try/except/finally blocks are appropriate, the default block sizes could be set to 25, 23, and 13 respectively.