### PR TITLE
Allow global vars that are constants or type definitions

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -1,3 +1,4 @@
+import re
 import typing  # pylint: disable=unused-import
 
 import astroid  # pylint: disable=unused-import
@@ -6,6 +7,7 @@ import six
 from pylint import checkers
 from pylint import interfaces
 from pylint import lint  # pylint: disable=unused-import
+from pylint import utils
 
 
 def register_checkers(linter):  # type: (lint.PyLinter) -> None
@@ -105,17 +107,27 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
     def __avoid_global_variables(self, node):  # type: (astroid.Assign) -> None
         """Avoid global variables."""
+
+        def check_assignment(node):
+            if utils.get_global_option(self, 'class-rgx').match(node.name):
+                return  # Type definitions are allowed if the assign to a class name
+
+            if utils.get_global_option(self, 'const-rgx').match(node.name) or \
+               re.match('^__[a-z]+__$', node.name):
+                if isinstance(node.parent.value, astroid.Const):
+                    return  # Constants are allowed
+
+            self.add_message('global-variable', node=node, args={'name': node.name})
+
         # Is this an assignment happening within a module? If so report on each assignment name
         # whether its in a tuple or not
         if isinstance(node.parent, astroid.Module):
             for target in node.targets:
                 if hasattr(target, 'elts'):
                     for elt in target.elts:
-                        if elt.name != '__version__':
-                            self.add_message('global-variable', node=elt)
+                        check_assignment(elt)
                 elif hasattr(target, 'name'):
-                    if target.name != '__version__':
-                        self.add_message('global-variable', node=target)
+                    check_assignment(target)
 
     def __dont_use_archaic_raise_syntax(self, node):  # type: (astroid.Raise) -> None
         """Don't use the two-argument form of raise or the string raise"""

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -110,7 +110,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
         def check_assignment(node):
             if utils.get_global_option(self, 'class-rgx').match(node.name):
-                return  # Type definitions are allowed if the assign to a class name
+                return  # Type definitions are allowed if they assign to a class name
 
             if utils.get_global_option(self, 'const-rgx').match(node.name) or \
                re.match('^__[a-z]+__$', node.name):

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -39,7 +39,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         'C2602': ('%(module)s imported relatively',
                   'import-full-path',
                   'Import %(module)s using the absolute name.'),
-        'C2603': ('Variable declared at the module level (i.e. global)',
+        'C2603': ('%(name)s declared at the module level (i.e. global)',
                   'global-variable',
                   'Avoid global variables in favor of class variables'),
         'C2604': ('Raised two-argument exception',

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -57,16 +57,26 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         ):
             self.walk(root)
 
-    def test_global_variables_fail(self):
+    def test_global_variables(self):
         root = astroid.builder.parse("""
         module_var, other_module_var = 10
+        another_module_var = 1
         __version__ = '0.0.0'
+        CONSTANT = 10
+        NOT_A_CONSTANT = sum(x)
+        Point = namedtuple('Point', ['x', 'y'])
         class MyClass(object):
             class_var = 10
         """)
         with self.assertAddsMessages(
-            pylint.testutils.Message('global-variable', node=root.body[0].targets[0].elts[0]),
-            pylint.testutils.Message('global-variable', node=root.body[0].targets[0].elts[1]),
+            pylint.testutils.Message(
+                'global-variable', node=root.body[0].targets[0].elts[0], args={'name': 'module_var'}),
+            pylint.testutils.Message(
+                'global-variable', node=root.body[0].targets[0].elts[1], args={'name': 'other_module_var'}),
+            pylint.testutils.Message(
+                'global-variable', node=root.body[1].targets[0], args={'name': 'another_module_var'}),
+            pylint.testutils.Message(
+                'global-variable', node=root.body[4].targets[0], args={'name': 'NOT_A_CONSTANT'}),
         ):
             self.walk(root)
 


### PR DESCRIPTION
This PR lessens the restrictions on global vars to allow:
  - Any dunder-var (e.g. `__version__`);
  - Any uppercase variable that is assigned a constant (e.g. `CONSTANT_NAME = 10`); and
  - Any class-name-style variable assignment (to allow `namedtuple` and other type declarations).