### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -6,7 +6,7 @@ from pylint import lint
 from shopify_python import google_styleguide
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
Let's cut a bugfix release that adds these PRs:
  - Document already-handled rules https://github.com/Shopify/shopify_python/pull/11
  - Allow global vars that are constants or type definitions https://github.com/Shopify/shopify_python/pull/14
  - Allow all assignment types to global constants https://github.com/Shopify/shopify_python/pull/16