### PR TITLE
Allow all assignment types to global constants

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -114,8 +114,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
             if utils.get_global_option(self, 'const-rgx').match(node.name) or \
                re.match('^__[a-z]+__$', node.name):
-                if isinstance(node.parent.value, astroid.Const):
-                    return  # Constants are allowed
+                return  # Constants are allowed
 
             self.add_message('global-variable', node=node, args={'name': node.name})
 

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -63,7 +63,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         another_module_var = 1
         __version__ = '0.0.0'
         CONSTANT = 10
-        NOT_A_CONSTANT = sum(x)
+        OTHER_CONSTANT = sum(x)
         Point = namedtuple('Point', ['x', 'y'])
         class MyClass(object):
             class_var = 10
@@ -75,8 +75,6 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
                 'global-variable', node=root.body[0].targets[0].elts[1], args={'name': 'other_module_var'}),
             pylint.testutils.Message(
                 'global-variable', node=root.body[1].targets[0], args={'name': 'another_module_var'}),
-            pylint.testutils.Message(
-                'global-variable', node=root.body[4].targets[0], args={'name': 'NOT_A_CONSTANT'}),
         ):
             self.walk(root)
 

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -63,8 +63,9 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         another_module_var = 1
         __version__ = '0.0.0'
         CONSTANT = 10
-        OTHER_CONSTANT = sum(x)
+        _OTHER_CONSTANT = sum(x)
         Point = namedtuple('Point', ['x', 'y'])
+        _Point = namedtuple('_Point', ['x', 'y'])
         class MyClass(object):
             class_var = 10
         """)


### PR DESCRIPTION
This PR lessens the restrictions on global constants to allow the assignment of any type of object.

[> If the developer uses a naming convention to tell other developers that it's a const, we should believe them.](https://github.com/Shopify/shopify_python/pull/14#discussion_r104935752)

