### PR TITLE
Not everyone needs to use version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ exceptions:
 
 ## Versioning
 
-Project version numbering follows [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html), i.e.
+Project that are producing libraries to be used in other projects should choose their release version numbers using [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html), i.e.
 
 > Given a version number MAJOR.MINOR.PATCH, increment the:
 > 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ exceptions:
 
 ## Versioning
 
-Project that are producing libraries to be used in other projects should choose their release version numbers using [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html), i.e.
+Projects that are producing libraries to be used in other projects should choose their release version numbers using [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.html), i.e.
 
 > Given a version number MAJOR.MINOR.PATCH, increment the:
 > 


### PR DESCRIPTION
Version numbers are only really useful for libraries that are used in other projects. Applications don't need to be versioned (especially if they are continuously deployed).