### PR TITLE
add new check for multiple imports

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -63,9 +63,10 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   'finally-too-long',
                   "The larger the 'finally' body size, the more likely that an exception will be raised during "
                   "resource cleanup activities."),
-        'C6010': ('Multiple items imported from %(module)s in one import statement.',
+        'C6010': ('Statement imports multiple items from %(module)s',
                   'multiple-import-items',
-                  'Separate imports into one item per line.')
+                  'Multiple imports usually result in noisy and potentially conflicting git diffs. To alleviate, '
+                  'separate imports into one item per line.')
     }
 
     options = (

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -63,6 +63,9 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   'finally-too-long',
                   "The larger the 'finally' body size, the more likely that an exception will be raised during "
                   "resource cleanup activities."),
+        'C2610': ('%s imports multiple items in one import statement',
+                  'multiple-import-items',
+                  'Separate imports into one item per line.')
     }
 
     options = (
@@ -99,6 +102,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
     def visit_importfrom(self, node):  # type: (astroid.ImportFrom) -> None
         self.__import_modules_only(node)
         self.__import_full_path_only(node)
+        self.__limit_one_import(node)
 
     def visit_raise(self, node):  # type: (astroid.Raise) -> None
         self.__dont_use_archaic_raise_syntax(node)
@@ -135,6 +139,11 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         if node.level:
             for child_module in self.__get_module_names(node):
                 self.add_message('import-full-path', node=node, args={'module': child_module})
+
+    def __limit_one_import(self, node):  # type: (astroid.ImportFrom) -> None
+        """Only one item imported per line."""
+        if len(node.names) > 1:
+            self.add_message('multiple-import-items', node=node)
 
     def __avoid_global_variables(self, node):  # type: (astroid.Assign) -> None
         """Avoid global variables."""

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -63,7 +63,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   'finally-too-long',
                   "The larger the 'finally' body size, the more likely that an exception will be raised during "
                   "resource cleanup activities."),
-        'C2610': ('%s imports multiple items in one import statement',
+        'C6010': ('Multiple items imported from %(module)s in one import statement.',
                   'multiple-import-items',
                   'Separate imports into one item per line.')
     }
@@ -143,7 +143,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
     def __limit_one_import(self, node):  # type: (astroid.ImportFrom) -> None
         """Only one item imported per line."""
         if len(node.names) > 1:
-            self.add_message('multiple-import-items', node=node)
+            self.add_message('multiple-import-items', node=node, args={'module': node.modname})
 
     def __avoid_global_variables(self, node):  # type: (astroid.Assign) -> None
         """Avoid global variables."""

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -167,6 +167,6 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         """)
 
         module2_node = root['module2']
-        message = pylint.testutils.Message('multiple-import-items', node=module2_node)
+        message = pylint.testutils.Message('multiple-import-items', node=module2_node, args={'module': 'package.module'})
         with self.assert_adds_code_messages(['multiple-import-items'], message):
             self.walk(root)

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -1,3 +1,4 @@
+import contextlib
 import sys
 
 import astroid
@@ -10,6 +11,16 @@ from shopify_python import google_styleguide
 class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
 
     CHECKER_CLASS = google_styleguide.GoogleStyleGuideChecker
+
+    @contextlib.contextmanager
+    def assert_adds_code_messages(self, codes, *messages):
+        """Asserts that the checker received the list of messages, including only messages with the given codes."""
+        yield
+        got = [message for message in self.linter.release_messages() if message[0] in codes]
+        msg = ('Expected messages did not match actual.\n'
+               'Expected:\n%s\nGot:\n%s' % ('\n'.join(repr(m) for m in messages),
+                                            '\n'.join(repr(m) for m in got)))
+        self.assertEqual(list(messages), got, msg)
 
     def test_importing_function_fails(self):
         root = astroid.builder.parse("""
@@ -50,7 +61,8 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         from . import string
         from .. import string, os
         """)
-        with self.assertAddsMessages(
+        with self.assert_adds_code_messages(
+            ['import-full-path'],
             pylint.testutils.Message('import-full-path', node=root.body[0], args={'module': '.string'}),
             pylint.testutils.Message('import-full-path', node=root.body[1], args={'module': '.string'}),
             pylint.testutils.Message('import-full-path', node=root.body[1], args={'module': '.os'}),
@@ -145,4 +157,16 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
             pylint.testutils.Message('try-too-long', node=try_except, args={'found': 28}),
             pylint.testutils.Message('except-too-long', node=try_except.handlers[0], args={'found': 39}),
         ):
+            self.walk(root)
+
+    def test_multiple_from_imports(self):
+        root = astroid.builder.parse("""
+        import sys
+        from package.module import module1, module2
+        from other_package import other_module as F
+        """)
+
+        module2_node = root['module2']
+        message = pylint.testutils.Message('multiple-import-items', node=module2_node)
+        with self.assert_adds_code_messages(['multiple-import-items'], message):
             self.walk(root)


### PR DESCRIPTION
This PR introduces a new import check, restricting imports to one import per line:
```
from foo import bar  # OK
from foo import baz # OK
from foo import bar, baz  # forbidden
```
This PR also ran up against other rule checks, so I created a new assertion checker that allows you to limit which codes are verified. This makes tests less fragile (no interdependencies between codes). Also, consumers may disable individual codes, so it's important that we test a code in isolation, whether or not it also fails other checks.

@cfournie @honkfestival 