### PR TITLE
increase maximum length of function and method names

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -147,10 +147,10 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression which should only match correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=[a-z_][a-z0-9_]{2,90}$
 
 # Regular expression which should only match correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,90}$
 
 # Regular expression which should only match correct instance attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$


### PR DESCRIPTION
I find 30 characters for a function or method name way too short, particularly for descriptive test method names. What do you think of 90?

@cfournie @erikwright ?