### PR TITLE
change pylint output format

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -43,7 +43,7 @@ disable=C0111,redefined-outer-name
 
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html
-output-format=text
+output-format=colorized
 
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be
@@ -64,6 +64,8 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # Add a comment according to your evaluation note. This is used by the global
 # evaluation report (RP0004).
 comment=no
+
+msg-template="{path}:{line}:{column} {msg_id}({symbol}) {msg}"
 
 
 [VARIABLES]


### PR DESCRIPTION
This PR makes the pylint output much more readable in my opinion.

Current master
![1 ipython- code-shopify_python bash 2017-03-11 00-00-59](https://cloud.githubusercontent.com/assets/2893818/23820766/dec30888-05ed-11e7-8887-21d01cd7258c.png)

This PR:
![1 ipython code shopify_python bash 2017-03-11 00-02-00](https://cloud.githubusercontent.com/assets/2893818/23820773/01926c6e-05ee-11e7-88a2-ba358ead28a8.png)

This PR, without being colorized:
![1 ipython code shopify_python bash 2017-03-11 00-02-45](https://cloud.githubusercontent.com/assets/2893818/23820776/13046bbe-05ee-11e7-8626-709aa2212515.png)

Thoughts? @cfournie @honkfestival 