### PR TITLE
Use simple lambdas

### DIFF
--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -7,6 +7,7 @@ from git.refs import head  # pylint: disable=unused-import
 class GitUtilsException(Exception):
     pass
 
+
 def _remote_origin_master(git_repo):
     # type: (repo.Repo) -> head.Head
     remote_master = git_repo.heads.master.tracking_branch()
@@ -14,11 +15,13 @@ def _remote_origin_master(git_repo):
         raise GitUtilsException("Unable to locate remote branch origin/master")
     return remote_master
 
+
 def _modified_in_branch(git_repo, other_ref):
     # type: (repo.Repo, head.Head) -> typing.List[str]
     commit = git_repo.active_branch.commit
     modified = [x for x in commit.diff(other_ref.commit, R=True) if not x.deleted_file]
     return [x.b_path for x in modified]
+
 
 def _file_is_python(path):
     # type: (str) -> bool
@@ -34,6 +37,7 @@ def _file_is_python(path):
             except UnicodeDecodeError:
                 pass
         return False
+
 
 def changed_python_files_in_tree(root_path):
     # type: (str) -> typing.List[str]

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -67,7 +67,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   'multiple-import-items',
                   'Multiple imports usually result in noisy and potentially conflicting git diffs. To alleviate, '
                   'separate imports into one item per line.'),
-        'C2611': ('Lambda has %(found)i nodes',
+        'C6011': ('Lambda has %(found)i nodes',
                   'lambda-too-long',
                   "Okay to use them for one-liners. If the code inside the lambda function is any longer than a "
                   "certain length, it's probably better to define it as a regular (nested) function."),

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -4,6 +4,7 @@ import pytest
 from git import repo
 from shopify_python import git_utils
 
+
 @pytest.fixture
 def python_file(main_repo):
     # type: (repo.Repo) -> str
@@ -17,6 +18,7 @@ def python_file(main_repo):
     with open(file_path, 'w') as writing_file:
         writing_file.writelines(file_lines)
     return file_path
+
 
 @pytest.fixture
 def python_script(main_repo):
@@ -33,6 +35,7 @@ def python_script(main_repo):
         writing_file.writelines(file_lines)
     return file_path
 
+
 @pytest.fixture
 def non_python_file(main_repo):
     # type: (repo.Repo) -> str
@@ -47,10 +50,12 @@ def non_python_file(main_repo):
         writing_file.writelines(file_lines)
     return file_path
 
+
 @pytest.fixture
 def remote_repo(tmpdir):
     # type: ('py.path.LocalPath') -> repo.Repo
     return repo.Repo.init(str(tmpdir.join('remote')), bare=True)
+
 
 @pytest.fixture
 def main_repo(tmpdir, remote_repo):
@@ -66,6 +71,7 @@ def main_repo(tmpdir, remote_repo):
 
     return new_repo
 
+
 def test_detects_changed_python_files(main_repo, python_file, python_script):
     # type: (repo.Repo, str, str) -> None
 
@@ -79,6 +85,7 @@ def test_detects_changed_python_files(main_repo, python_file, python_script):
         os.path.basename(python_file),
     ]
 
+
 def test_doesnt_include_changed_nonpython_files(main_repo, python_file, non_python_file):
     # type: (repo.Repo, str, str) -> None
 
@@ -88,6 +95,7 @@ def test_doesnt_include_changed_nonpython_files(main_repo, python_file, non_pyth
 
     changed_files = git_utils.changed_python_files_in_tree(main_repo.working_dir)
     assert changed_files == [os.path.basename(python_file)]
+
 
 def test_only_include_modified_locally(main_repo, python_file):
     # type: (repo.Repo, str) -> None
@@ -118,6 +126,7 @@ def test_only_include_modified_locally(main_repo, python_file):
     # only the one new file is added
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
 
+
 def test_cant_find_remote_origin(main_repo, remote_repo):
     # type: (repo.Repo, repo.Repo) -> None
     main_repo.create_remote('foo', remote_repo.working_dir)
@@ -126,6 +135,7 @@ def test_cant_find_remote_origin(main_repo, remote_repo):
     with pytest.raises(git_utils.GitUtilsException) as ex:
         git_utils.changed_python_files_in_tree(main_repo.working_dir)
     assert "Unable to locate remote branch origin/master" in ex.exconly()
+
 
 def test_cant_find_origin_master(main_repo, remote_repo):
     # type: (repo.Repo, repo.Repo) -> None
@@ -140,6 +150,7 @@ def test_cant_find_origin_master(main_repo, remote_repo):
         git_utils.changed_python_files_in_tree(main_repo.working_dir)
     assert "Unable to locate remote branch origin/master" in ex.exconly()
 
+
 def test_dont_include_deleted_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
@@ -153,6 +164,7 @@ def test_dont_include_deleted_files(main_repo, python_file):
     main_repo.index.commit("removing python file")
 
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == []
+
 
 def test_include_modified_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
@@ -170,6 +182,7 @@ def test_include_modified_files(main_repo, python_file):
     main_repo.index.commit("modifying python file")
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
 
+
 def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
@@ -179,6 +192,7 @@ def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == []
     main_repo.index.commit("adding python file")
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
+
 
 def test_dont_include_scripts_with_extensions(main_repo):
     # type: (repo.Repo) -> None
@@ -194,6 +208,7 @@ def test_dont_include_scripts_with_extensions(main_repo):
     main_repo.index.add([file_path])
     main_repo.index.commit("adding script file with .sh extension")
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == []
+
 
 def test_dont_include_binary_files(main_repo):
     # type: (repo.Repo) -> None

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -167,6 +167,22 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         """)
 
         module2_node = root['module2']
-        message = pylint.testutils.Message('multiple-import-items', node=module2_node, args={'module': 'package.module'})
+        message = pylint.testutils.Message(
+            'multiple-import-items',
+            node=module2_node,
+            args={
+                'module': 'package.module'})
         with self.assert_adds_code_messages(['multiple-import-items'], message):
+            self.walk(root)
+
+    def test_use_simple_lamndas(self):
+        root = astroid.builder.parse("""
+        def fnc():
+            good = lambda x, y: x if x % 2 == 0 else y
+            bad = lambda x, y: (x * 2 * 3 + 4) if x % 2 == 0 else (y * 2 * 3 + 4)
+        """)
+        fnc = root.body[0]
+        bad_list_comp = fnc.body[1].value
+        message = pylint.testutils.Message('use-simple-lambdas', node=bad_list_comp)
+        with self.assertAddsMessages(message):
             self.walk(root)


### PR DESCRIPTION
Lambdas can be very useful but they are "[h]arder to read and debug than local functions. The lack of names means stack traces are more difficult to understand. Expressiveness is limited because the function may only contain an expression."

To limit need to debug lambdas let's encourage them to be simple and to have a maximum number os AST nodes. The default of 15 was chosen arbitrarily.