### PR TITLE
Missing type annotation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ autopep8:
 lint:
 	@echo 'Linting...'
 	@pylint --rcfile=pylintrc setup.py shopify_python tests.shopify_python
-	@if [ "$(python_version_major)" == "3" ]; then \
+	@if [ "$(python_version_major)" = "3" ]; then \
 		echo 'Checking type annotations...'; \
 		mypy --py2 shopify_python tests/shopify_python --ignore-missing-imports; \
 	fi

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuplib.setup(
             'autopep8',
             'pytest',
             'pytest-randomly',
-            'mypy; python_version > "3.3"',
+            'mypy; python_version >= "3.3"',
         ]
     }
 )

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -32,7 +32,8 @@ def _file_is_python(path):
                     line = might_be_python.readline()
                     return line.startswith('#!') and 'python' in line
             except UnicodeDecodeError:
-                return False
+                pass
+        return False
 
 def changed_python_files_in_tree(root_path):
     # type: (str) -> typing.List[str]


### PR DESCRIPTION
Because on Travis CI we're executing this makefile with `sh` (which doesn't support `==` comparisons), we were skipping type annotation checking and make returns:

```
/bin/sh: 1: [: 3: unexpected operator
```

This PR fixes this issue, a type annotation issue, and installs `mypy` for Python 3.3 because it was missing.