### PR TITLE
Disable by msg name not code in pylintrc

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -34,9 +34,9 @@ load-plugins=shopify_python
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
 # CHANGED:
-# C0111: Missing docstring
+# missing-docstring: docstrings should be optional
 # redefined-outer-name: doesn't play well with pytest fixtures
-disable=C0111,redefined-outer-name
+disable=missing-docstring,redefined-outer-name
 
 
 [REPORTS]


### PR DESCRIPTION
This PR substitutes `C0111 ` with `missing-docstring` in `pylintrc` and adds an explanation as to why.