### PR TITLE
Pep8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 before_install:
   - pip install -U pip setuptools
 install:
-  - make setup_dev
+  - make install
 script:
   - make test
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 install:
   - make install
 script:
-  - make test
+  - make run_tests
+  - make lint
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ lint:
 		echo 'Checking type annotations...'; \
 		mypy --py2 shopify_python tests/shopify_python --ignore-missing-imports; \
 	fi
+	@pep8
 
 autolint: autopep8 lint
 
@@ -29,8 +30,5 @@ run_tests: clean
 
 test: autopep8 run_tests lint
 
-setup_dev:
+install:
 	pip install -e .[dev]
-
-setup:
-	pip install .

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean:
 
 autopep8:
 	@echo 'Auto Formatting...'
-	@$(python_files) | xargs -0 autopep8 --max-line-length 120 --jobs 0 --in-place --aggressive
+	@$(python_files) | xargs -0 autopep8 --jobs 0 --in-place --aggressive
 
 lint:
 	@echo 'Linting...'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pep8]
+max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pep8]
 max-line-length = 120
+
+[autopep8]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -39,18 +39,19 @@ setuplib.setup(
     ],
     test_suite='tests',
     install_requires=[
+        'GitPython==2.1.1',
         'pylint==1.6.5',
         'six>=1.10.0',
         'typing>=3.5.3.0',
-        'GitPython==2.1.1',
     ],
     extras_require={
         'dev': [
             'autopep8',
+            'mock; python_version < "3.3"',
+            'mypy; python_version >= "3.3"',
+            'pep8',
             'pytest',
             'pytest-randomly',
-            'mypy; python_version >= "3.3"',
-            'mock; python_version < "3.3"',
         ]
     }
 )


### PR DESCRIPTION
Some PRs have not been adding sufficient newlines such that running `autopep8` would introduce some. This PR tries to prevent that by running `pep8` as part of the tests and removing autopep8 on CI.