### PR TITLE
Fix message name and increase version to 0.2.1

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -68,7 +68,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   'Multiple imports usually result in noisy and potentially conflicting git diffs. To alleviate, '
                   'separate imports into one item per line.'),
         'C6011': ('Lambda has %(found)i nodes',
-                  'lambda-too-long',
+                  'use-simple-lambdas',
                   "Okay to use them for one-liners. If the code inside the lambda function is any longer than a "
                   "certain length, it's probably better to define it as a regular (nested) function."),
         'C6012': ('Multiple generators in list comprehension',


### PR DESCRIPTION
This PR proposes a bugfix release (v0.2.1) and fixes a mismatch between a message name added versus defined (`__use_simple_lambdas` adds `use-simple-lambdas` whereas `C6011` was defined as `lambda-too-long`).

A test to prevent this should be added in the future https://github.com/Shopify/shopify_python/issues/45.

Fixes https://github.com/Shopify/shopify_python/issues/43.