### PR TITLE
Fix missing formatting constant value and increase version to v0.2.2

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.2.1'
+__version__ = '0.2.2'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -221,8 +221,9 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
             self.add_message('finally-too-long', node=node, args={'found': finally_body_nodes})
 
     def __use_simple_lambdas(self, node):  # type: (astroid.Lambda) -> None
-        if shopify_python.ast.count_tree_size(node) > self.config.max_lambda_nodes:  # pylint: disable=no-member
-            self.add_message('use-simple-lambdas', node=node)
+        lambda_nodes = shopify_python.ast.count_tree_size(node)
+        if lambda_nodes > self.config.max_lambda_nodes:  # pylint: disable=no-member
+            self.add_message('use-simple-lambdas', node=node, args={'found': lambda_nodes})
 
     def __use_simple_list_comp(self, node):  # type: (astroid.ListComp) -> None
         """List comprehensions are okay to use for simple cases."""

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -175,7 +175,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         with self.assert_adds_code_messages(['multiple-import-items'], message):
             self.walk(root)
 
-    def test_use_simple_lamndas(self):
+    def test_use_simple_lambdas(self):
         root = astroid.builder.parse("""
         def fnc():
             good = lambda x, y: x if x % 2 == 0 else y
@@ -183,7 +183,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         """)
         fnc = root.body[0]
         bad_list_comp = fnc.body[1].value
-        message = pylint.testutils.Message('use-simple-lambdas', node=bad_list_comp)
+        message = pylint.testutils.Message('use-simple-lambdas', node=bad_list_comp, args={'found': 24})
         with self.assertAddsMessages(message):
             self.walk(root)
 


### PR DESCRIPTION
https://github.com/Shopify/shopify_python/pull/44 didn't fix the missing formatting constant.

We need integration tests https://github.com/Shopify/shopify_python/issues/45.