### PR TITLE
Add autopep utility

### DIFF
--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -1,7 +1,9 @@
 import os
+import sys
 import typing  # pylint: disable=unused-import
 from git import repo
 from git.refs import head  # pylint: disable=unused-import
+import autopep8
 
 
 class GitUtilsException(Exception):
@@ -48,3 +50,47 @@ def changed_python_files_in_tree(root_path):
     abs_modified = [os.path.join(git_repo.working_dir, x) for x in modified]
     return [mod for (mod, abs_mod) in zip(modified, abs_modified)
             if os.path.exists(abs_mod) and os.path.isfile(abs_mod) and _file_is_python(abs_mod)]
+
+
+_AutopepOptions = typing.NamedTuple('_AutopepOptions', [  # pylint: disable=global-variable,invalid-name
+    ('aggressive', int),
+    ('diff', bool),
+    ('exclude', typing.Set[typing.List[str]]),
+    ('experimental', bool),
+    ('global_config', typing.Optional[typing.List[str]]),
+    ('ignore', str),
+    ('ignore_local_config', bool),
+    ('in_place', bool),
+    ('indent_size', int),
+    ('jobs', int),
+    ('line_range', typing.Optional[typing.Sequence]),
+    ('list_fixes', bool),
+    ('max_line_length', int),
+    ('pep8_passes', int),
+    ('recursive', bool),
+    ('select', typing.Set[str]),
+    ('verbose', int),
+])
+
+
+def autopep_files(files, max_line_length):
+    # type: (typing.List[str], int) -> None
+    files = files[:]
+    options = _AutopepOptions(aggressive=1,  # pylint:disable=not-callable
+                              diff=False,
+                              exclude=set(),
+                              experimental=False,
+                              global_config=None,
+                              ignore='',
+                              ignore_local_config=False,
+                              in_place=True,
+                              indent_size=4,
+                              jobs=0,
+                              line_range=None,
+                              list_fixes=False,
+                              max_line_length=max_line_length,
+                              pep8_passes=-1,
+                              recursive=False,
+                              select={'W', 'E'},
+                              verbose=0)
+    autopep8.fix_multiple_files(files, options, sys.stdout)

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -52,6 +52,7 @@ def changed_python_files_in_tree(root_path):
             if os.path.exists(abs_mod) and os.path.isfile(abs_mod) and _file_is_python(abs_mod)]
 
 
+# Options are defined here: https://pypi.python.org/pypi/autopep8#usage
 _AutopepOptions = typing.NamedTuple('_AutopepOptions', [  # pylint: disable=global-variable,invalid-name
     ('aggressive', int),
     ('diff', bool),

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -219,3 +219,32 @@ def test_dont_include_binary_files(main_repo):
     main_repo.index.add([file_path])
     main_repo.index.commit("adding binary file")
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == []
+
+
+def test_autopep_files(tmpdir):
+    # type: ('py.path.LocalPath') -> None
+    file_lines = [
+        "def foo():\n",
+        "    return 1\n",
+        "def bar():\n",
+        "    return 2\n",
+    ]
+    file1_path = os.path.join(str(tmpdir), 'file1.py')
+    file2_path = os.path.join(str(tmpdir), 'file2.py')
+    with open(file1_path, 'w') as file1:
+        file1.writelines(file_lines)
+
+    file_lines.insert(2, "\n")
+    file_lines.insert(2, "\n")
+    assert len(file_lines) == 6
+
+    with open(file2_path, 'w') as file2:
+        file2.writelines(file_lines)
+    files_to_autopep = [file1_path, file2_path]
+
+    git_utils.autopep_files(files_to_autopep, 79)
+    assert len(files_to_autopep) == 2
+
+    for fixed_file in files_to_autopep:
+        with open(fixed_file) as file_to_check:
+            assert file_to_check.readlines() == file_lines


### PR DESCRIPTION
This PR introduces a replacement for the "autopep" portion of the github pre-push hook. It's pretty simple, just calls the `autopep8.fix_multiple_files` with appropriate options to fix files in-place, using the same settings as starscream and data_bang currently use.

I've made the interface a little more generic so we can choose to expose additional options in the future if necessary.

@cfournie What do you think?