### PR TITLE
add pylint utility

### DIFF
--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -99,8 +99,12 @@ def autopep_files(files, max_line_length):
 
 
 def pylint_files(files, **kwargs):
-    # type: (typing.List[str], **str) -> typing.List[str]
+    # type: (typing.List[str], **str) -> typing.Iterable[str]
     file_string = " ".join(files)
     args = " ".join(["--{}={}".format(key, value) for key, value in kwargs.items()])
     stdout, _ = lint.py_run("{} {}".format(file_string, args), return_std=True)
-    return stdout.readlines()
+    while True:
+        line = stdout.readline()
+        if line == '':
+            break
+        yield line

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -1,9 +1,10 @@
 import os
 import sys
 import typing  # pylint: disable=unused-import
+import autopep8
 from git import repo
 from git.refs import head  # pylint: disable=unused-import
-import autopep8
+from pylint import epylint as lint
 
 
 class GitUtilsException(Exception):
@@ -95,3 +96,11 @@ def autopep_files(files, max_line_length):
                               select={'W', 'E'},
                               verbose=0)
     autopep8.fix_multiple_files(files, options, sys.stdout)
+
+
+def pylint_files(files, **kwargs):
+    # type: (typing.List[str], **str) -> typing.List[str]
+    file_string = " ".join(files)
+    args = " ".join(["--{}={}".format(key, value) for key, value in kwargs.items()])
+    stdout, _ = lint.py_run("{} {}".format(file_string, args), return_std=True)
+    return stdout.readlines()

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -252,69 +252,63 @@ def test_autopep_files(tmpdir):
 
 def test_linter(tmpdir):
     # type: ('py.path.LocalPath') -> None
-    open(os.path.join(str(tmpdir), '__init__.py'), 'w')
+    open(str(tmpdir.join('__init__.py')), 'w')
 
     file_lines = [
         "def foo():\n",
         "  return 1\n"
     ]
-    file_path = os.path.join(str(tmpdir), 'file.py')
-    with open(file_path, 'w') as file_to_write:
-        file_to_write.writelines(file_lines)
+    tmpdir.join('file.py').write('\n'.join(file_lines))
 
     lint_results = [x for x in git_utils.pylint_files([str(tmpdir)])]
-    import ipdb
-    ipdb.set_trace()
 
-    expected_failure = 'file.py:2: warning (W0311, bad-indentation, ) Bad indentation. Found 2 spaces, expected 4'
-    assert lint_results[1].strip().endswith(expected_failure)
+    assert len(lint_results) == 2
+    assert lint_results[0].symbol == 'bad-indentation'
+    assert lint_results[1].symbol == 'blacklisted-name'
 
 
 def test_linter_with_config(tmpdir):
     # type: ('py.path.LocalPath') -> None
-    open(os.path.join(str(tmpdir), '__init__.py'), 'w')
+    open(str(tmpdir.join('__init__.py')), 'w')
 
     file_lines = [
         "def my_function():    \n"
         "  return 1\n"
     ]
-    python_files = [os.path.join(str(tmpdir), filename) for filename in ['file1.py', 'file2.py']]
+    python_files = [tmpdir.join(filename) for filename in ['file1.py', 'file2.py']]
     for path in python_files:
-        with open(path, 'w') as file_to_write:
-            file_to_write.writelines(file_lines)
+        path.write('\n'.join(file_lines))
 
     pylintrc_lines = [
         "[MESSAGES CONTROL]\n",
         "disable=bad-indentation,missing-docstring\n"
     ]
-    pylintrc_path = os.path.join(str(tmpdir), 'pylintrc')
-    with open(pylintrc_path, 'w') as rcfile:
-        rcfile.writelines(pylintrc_lines)
+    pylintrc_path = tmpdir.join('pylintrc')
+    pylintrc_path.write('\n'.join(pylintrc_lines))
 
     msg_template = '"{path}:{line}:{column} {msg_id}({symbol}) {msg}"'
     options = {
-        'rcfile': pylintrc_path,
-        'ignore': os.path.basename(python_files[0]),
+        'rcfile': str(pylintrc_path),
+        'ignore': os.path.basename(str(python_files[0])),
         'msg-template': msg_template,
     }
     lint_results = [x for x in git_utils.pylint_files([str(tmpdir)], **options)]
 
-    assert len(lint_results) == 3
-    assert lint_results[1].strip().endswith('file2.py:1: convention (C0303, trailing-whitespace, ) Trailing whitespace')
+    assert len(lint_results) == 1
+    assert lint_results[0].path == python_files[1]
+    assert lint_results[0].symbol == 'trailing-whitespace'
 
 
 def test_passing_linter(tmpdir):
     # type: ('py.path.LocalPath') -> None
-    open(os.path.join(str(tmpdir), '__init__.py'), 'w')
+    open(str(tmpdir.join('__init__.py')), 'w')
 
     file_lines = [
         "def my_function():\n"
         '    """This is a docstring."""\n',
         "    return 1\n"
     ]
-    file_path = os.path.join(str(tmpdir), 'file.py')
-    with open(file_path, 'w') as file_to_write:
-        file_to_write.writelines(file_lines)
+    tmpdir.join('file.py').write('\n'.join(file_lines))
 
     lint_results = [x for x in git_utils.pylint_files([str(tmpdir)], reports='n')]
     assert lint_results == []

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -254,11 +254,11 @@ def test_linter(tmpdir):
     # type: ('py.path.LocalPath') -> None
     open(str(tmpdir.join('__init__.py')), 'w')
 
-    file_lines = [
-        "def foo():",
+    file_text = (
+        "def foo():\n"
         "  return 1\n"
-    ]
-    tmpdir.join('file.py').write('\n'.join(file_lines))
+    )
+    tmpdir.join('file.py').write(file_text)
 
     lint_results = [x for x in git_utils.pylint_files([str(tmpdir)])]
 
@@ -271,20 +271,18 @@ def test_linter_with_config(tmpdir):
     # type: ('py.path.LocalPath') -> None
     open(str(tmpdir.join('__init__.py')), 'w')
 
-    file_lines = [
-        "def my_function():    ",
+    file_text = (
+        "def my_function():    \n"
         "  return 1\n"
-    ]
+    )
     python_files = [tmpdir.join(filename) for filename in ['file1.py', 'file2.py']]
     for path in python_files:
-        path.write('\n'.join(file_lines))
+        path.write(file_text)
 
-    pylintrc_lines = [
-        "[MESSAGES CONTROL]\n",
-        "disable=bad-indentation,missing-docstring\n"
-    ]
+    pylintrc_text = """[MESSAGES CONTROL]
+        disable=bad-indentation,missing-docstring\n"""
     pylintrc_path = tmpdir.join('pylintrc')
-    pylintrc_path.write('\n'.join(pylintrc_lines))
+    pylintrc_path.write(pylintrc_text)
 
     msg_template = '"{path}:{line}:{column} {msg_id}({symbol}) {msg}"'
     options = {
@@ -303,12 +301,12 @@ def test_passing_linter(tmpdir):
     # type: ('py.path.LocalPath') -> None
     open(str(tmpdir.join('__init__.py')), 'w')
 
-    file_lines = [
+    file_text = (
         "def my_function():\n"
-        '    """This is a docstring."""',
+        '    """This is a docstring."""\n'
         "    return 1\n"
-    ]
-    tmpdir.join('file.py').write('\n'.join(file_lines))
+    )
+    tmpdir.join('file.py').write(file_text)
 
     lint_results = [x for x in git_utils.pylint_files([str(tmpdir)], reports='n')]
     assert lint_results == []

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -249,6 +249,7 @@ def test_autopep_files(tmpdir):
         with open(fixed_file) as file_to_check:
             assert file_to_check.readlines() == file_lines
 
+
 def test_linter(tmpdir):
     # type: ('py.path.LocalPath') -> None
     open(os.path.join(str(tmpdir), '__init__.py'), 'w')
@@ -261,7 +262,7 @@ def test_linter(tmpdir):
     with open(file_path, 'w') as file_to_write:
         file_to_write.writelines(file_lines)
 
-    lint_results = git_utils.pylint_files([str(tmpdir)])
+    lint_results = [x for x in git_utils.pylint_files([str(tmpdir)])]
 
     expected_failure = 'file.py:2: warning (W0311, bad-indentation, ) Bad indentation. Found 2 spaces, expected 4'
     assert lint_results[1].strip().endswith(expected_failure)
@@ -294,7 +295,7 @@ def test_linter_with_config(tmpdir):
         'ignore': os.path.basename(python_files[0]),
         'msg-template': msg_template,
     }
-    lint_results = git_utils.pylint_files([str(tmpdir)], **options)
+    lint_results = [x for x in git_utils.pylint_files([str(tmpdir)], **options)]
 
     assert len(lint_results) == 3
     assert lint_results[1].strip().endswith('file2.py:1: convention (C0303, trailing-whitespace, ) Trailing whitespace')
@@ -313,5 +314,5 @@ def test_passing_linter(tmpdir):
     with open(file_path, 'w') as file_to_write:
         file_to_write.writelines(file_lines)
 
-    lint_results = git_utils.pylint_files([str(tmpdir)])
+    lint_results = [x for x in git_utils.pylint_files([str(tmpdir)])]
     assert lint_results == []

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -255,7 +255,7 @@ def test_linter(tmpdir):
     open(str(tmpdir.join('__init__.py')), 'w')
 
     file_lines = [
-        "def foo():\n",
+        "def foo():",
         "  return 1\n"
     ]
     tmpdir.join('file.py').write('\n'.join(file_lines))
@@ -272,7 +272,7 @@ def test_linter_with_config(tmpdir):
     open(str(tmpdir.join('__init__.py')), 'w')
 
     file_lines = [
-        "def my_function():    \n"
+        "def my_function():    ",
         "  return 1\n"
     ]
     python_files = [tmpdir.join(filename) for filename in ['file1.py', 'file2.py']]
@@ -305,7 +305,7 @@ def test_passing_linter(tmpdir):
 
     file_lines = [
         "def my_function():\n"
-        '    """This is a docstring."""\n',
+        '    """This is a docstring."""',
         "    return 1\n"
     ]
     tmpdir.join('file.py').write('\n'.join(file_lines))

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -263,6 +263,8 @@ def test_linter(tmpdir):
         file_to_write.writelines(file_lines)
 
     lint_results = [x for x in git_utils.pylint_files([str(tmpdir)])]
+    import ipdb
+    ipdb.set_trace()
 
     expected_failure = 'file.py:2: warning (W0311, bad-indentation, ) Bad indentation. Found 2 spaces, expected 4'
     assert lint_results[1].strip().endswith(expected_failure)
@@ -314,5 +316,5 @@ def test_passing_linter(tmpdir):
     with open(file_path, 'w') as file_to_write:
         file_to_write.writelines(file_lines)
 
-    lint_results = [x for x in git_utils.pylint_files([str(tmpdir)])]
+    lint_results = [x for x in git_utils.pylint_files([str(tmpdir)], reports='n')]
     assert lint_results == []


### PR DESCRIPTION
Furthering the work to extract common functionality from `script/pre-push` files in various repos, this PR adds a simplified `pylint` interface for linting a passed list of files and/or directories.

It accepts all the "useful" command-line arguments, such as `rcfile`, `ignore`, and `msg-template`. If passed a path to a pylint configuration file, it will respect all customizations (ignored rules, message templates, regexes, etc). This allows this code to be used with a project's specific & customized configuration file.
