### PR TITLE
Replace pep8 with pycodestyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ lint:
 		echo 'Checking type annotations...'; \
 		mypy --py2 shopify_python tests/shopify_python --ignore-missing-imports; \
 	fi
-	@pep8
+	@pycodestyle
 
 autolint: autopep8 lint
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 max-line-length = 120
 
 [autopep8]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuplib.setup(
             'autopep8',
             'mock; python_version < "3.3"',
             'mypy; python_version >= "3.3"',
-            'pep8',
+            'pycodestyle == 2.2.0',
             'pytest',
             'pytest-randomly',
         ]


### PR DESCRIPTION
[pep8 was renamed](http://pep8.readthedocs.io/en/release-1.7.x/) [pycodestyle](https://github.com/PyCQA/pycodestyle).