### PR TITLE
Exact versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,12 @@ setuplib.setup(
     ],
     extras_require={
         'dev': [
-            'autopep8',
-            'mock; python_version < "3.3"',
-            'mypy; python_version >= "3.3"',
+            'autopep8 == 1.3.1',
+            'mock == 2.0.0; python_version < "3.3"',
+            'mypy == 0.501; python_version >= "3.3"',
             'pycodestyle == 2.2.0',
-            'pytest',
-            'pytest-randomly',
+            'pytest == 3.0.7',
+            'pytest-randomly == 1.1.2',
         ]
     }
 )


### PR DESCRIPTION
Let's pin our`extras_requires` for `dev` (aka development) to specific versions to prevent prevent spontaneous build failures if these dependencies change functionality.