### PR TITLE
Temporarily downgrade pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuplib.setup(
     test_suite='tests',
     install_requires=[
         'GitPython>=2.1.1,<3',
-        'pylint>=1.6.5,<2',
+        'pylint>=1.6.5,<1.7',
         'six>=1.10.0,<2',
         'typing>=3.5.3.0,<4',
         'autopep8>=1.2.2,<2',


### PR DESCRIPTION
1.7 was released and they changed some test utilities around and are [causing failures on master](https://travis-ci.org/Shopify/shopify_python/jobs/221730388).

This PR fixes this by temporarily pinning our pylint to pre 1.7.