### PR TITLE
replaced period

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -77,7 +77,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   'complex-list-comp',
                   "Complicated list comprehensions or generator expressions can be hard to read; "
                   "don't use multiple 'for' keywords"),
-        'C6013': ('Use Conditional Expressions for one-liners, For example: x = 1 if cond else 2.',
+        'C6013': ('Use Conditional Expressions for one-liners, for example: x = 1 if cond else 2.',
                   'cond-expr',
                   "Conditional expressions are mechanisms that provide a shorter syntax for if statements. "
                   "For example: x = 1 if cond else 2. "

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -77,7 +77,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                   'complex-list-comp',
                   "Complicated list comprehensions or generator expressions can be hard to read; "
                   "don't use multiple 'for' keywords"),
-        'C6013': ('Use Conditional Expressions for one-liners. For example: x = 1 if cond else 2.',
+        'C6013': ('Use Conditional Expressions for one-liners, For example: x = 1 if cond else 2.',
                   'cond-expr',
                   "Conditional expressions are mechanisms that provide a shorter syntax for if statements. "
                   "For example: x = 1 if cond else 2. "


### PR DESCRIPTION
One of the functional tests was failing because of a period in the `cond-expr` message that split the message into msg and confidence.

I'm replacing this period with a comma.