### PR TITLE
bump to pylint 1.7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setuplib.setup(
     test_suite='tests',
     install_requires=[
         'GitPython>=2.1.1,<3',
-        'pylint>=1.6.5,<1.7',
+        'pylint>=1.7.1,<1.8',
         'six>=1.10.0,<2',
         'typing>=3.5.3.0,<4',
         'autopep8>=1.2.2,<2',

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -185,8 +185,8 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                 args = {'child': child_module}
                 try:
                     parent.import_module(child_module)
-                except astroid.exceptions.AstroidBuildingException as building_exception:
-                    if str(building_exception).startswith('Unable to load module'):
+                except astroid.exceptions.AstroidImportError as building_exception:
+                    if str(building_exception).startswith('Failed to import module'):
                         self.add_message('import-modules-only', node=node, args=args)
                     else:
                         raise

--- a/shopify_python/shopify_styleguide.py
+++ b/shopify_python/shopify_styleguide.py
@@ -41,7 +41,7 @@ class ShopifyStyleGuideChecker(checkers.BaseTokenChecker):
                 def get_name(code):
                     try:
                         return self.linter.msgs_store.get_msg_display_string(code)
-                    except pylint.utils.UnknownMessage:
+                    except pylint.utils.UnknownMessageError:
                         return 'unknown'
 
                 matches = self.RE_PYLINT_DISABLE.match(string)

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -20,7 +20,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         msg = ('Expected messages did not match actual.\n'
                'Expected:\n%s\nGot:\n%s' % ('\n'.join(repr(m) for m in messages),
                                             '\n'.join(repr(m) for m in got)))
-        self.assertEqual(list(messages), got, msg)
+        assert list(messages) == got, msg
 
     def test_importing_function_fails(self):
         root = astroid.builder.parse("""


### PR DESCRIPTION
This PR bumps shopify_python to be compatible with Pylint 1.7.1 and up. I've explicitly dropped support for 1.6.5, let me know if you think we need to keep that in. The renaming of `pylint.utils.UnknownMessage` to `pylint.utils.UnknownMessageError` makes that a little more difficult.

Resolves https://github.com/Shopify/shopify_python/issues/68
