### PR TITLE
Add unary operators and resilience against unrecognized operators

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -302,3 +302,13 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
                     lambda_fun = "lambda " + left + ', ' + right + ": " + " ".join([left, node.op, right])
                     op_fun = "operator." + operator
                     self.add_message('lambda-func', node=node, args={'op': op_fun, 'lambda_fun': lambda_fun})
+        elif isinstance(node.body, astroid.Compare):
+            if shopify_python.ast.count_tree_size(node.body) == 3 and len(node.args.args) == 2:
+                node = node.body
+                operator = self.BINARY_OPERATORS[node.ops[0][0]]
+                if operator:
+                    left = str(node.left.value) if node.left.name == 'int' else node.left.name
+                    right = node.ops[0][1].name
+                    lambda_fun = "lambda " + left + ', ' + right + ": " + " ".join([left, node.ops[0][0], right])
+                    op_fun = "operator." + operator
+                    self.add_message('lambda-func', node=node, args={'op': op_fun, 'lambda_fun': lambda_fun})

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -131,7 +131,10 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         "==": "eq",
         "!=": "ne",
         ">=": "ge",
-        ">": "gt"
+        ">": "gt",
+        "&": "and_",
+        "|": "or_",
+        "^": "xor",
     }
 
     def visit_assign(self, node):  # type: (astroid.Assign) -> None
@@ -285,7 +288,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         """Prefer Operator Function to Lambda Functions"""
 
         if isinstance(node.body, astroid.UnaryOp):
-            operator = self.UNARY_OPERATORS[node.body.op]
+            operator = self.UNARY_OPERATORS.get(node.body.op, None)
             argname = node.args.args[0].name
             if operator and not isinstance(node.body.operand, astroid.BinOp) and argname is node.body.operand.name:
                 varname = node.body.operand.name
@@ -295,7 +298,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         elif isinstance(node.body, astroid.BinOp):
             if shopify_python.ast.count_tree_size(node.body) == 3 and len(node.args.args) == 2:
                 node = node.body
-                operator = self.BINARY_OPERATORS[node.op]
+                operator = self.BINARY_OPERATORS.get(node.op, None)
                 if operator:
                     left = str(node.left.value) if node.left.name == 'int' else node.left.name
                     right = str(node.right.value) if node.right.name == 'int' else node.right.name
@@ -305,7 +308,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         elif isinstance(node.body, astroid.Compare):
             if shopify_python.ast.count_tree_size(node.body) == 3 and len(node.args.args) == 2:
                 node = node.body
-                operator = self.BINARY_OPERATORS[node.ops[0][0]]
+                operator = self.BINARY_OPERATORS.get(node.ops[0][0], None)
                 if operator:
                     left = str(node.left.value) if node.left.name == 'int' else node.left.name
                     right = node.ops[0][1].name

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -267,7 +267,10 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         ('x == y', 'eq'),
         ('x != y', 'ne'),
         ('x >= y', 'ge'),
-        ('x > y', 'gt')
+        ('x > y', 'gt'),
+        ('x & y', 'and_'),
+        ('x | y', 'or_'),
+        ('x ^ y', 'xor'),
     ])
     def test_binary_lambda_func(self, test_case):
         (expression, op_name) = test_case
@@ -286,7 +289,8 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
 
     @pytest.mark.parametrize('expression', [
         'map(lambda x: x + 3, [1, 2, 3, 4])',
-        'reduce(lambda x, y, z: x * y + z, [1, 2, 3])'
+        'reduce(lambda x, y, z: x * y + z, [1, 2, 3])',
+        'reduce(lambda x, y: x in y, [1, 2, 3])'
     ])
     def test_allowed_binary_operation(self, expression):
         binary_root = astroid.builder.parse("""


### PR DESCRIPTION
@cfournie PTAL. Solves the following:

```
[2017-06-03T04:28:19Z]   File "/app/.tox/pylint/src/pylint/pylint/utils.py", line 970, in walk
[2017-06-03T04:28:19Z]     cb(astroid)
[2017-06-03T04:28:19Z]   File "/app/.tox/pylint/lib/python3.5/site-packages/shopify_python/google_styleguide.py", line 145, in visit_lambda
[2017-06-03T04:28:19Z]     self.__lambda_func(node)
[2017-06-03T04:28:19Z]   File "/app/.tox/pylint/lib/python3.5/site-packages/shopify_python/google_styleguide.py", line 298, in __lambda_func
[2017-06-03T04:28:19Z]     operator = self.BINARY_OPERATORS[node.op]
[2017-06-03T04:28:19Z] KeyError: '&'
```