### PR TITLE
Change how we specify environment markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run_tests: clean
 test: autopep8 run_tests lint
 
 install:
-	pip install -e .[dev,devpy2,devpy3]
+	pip install -e .[dev]
 
 release:
 	rm -rf build dist

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ run_tests: clean
 test: autopep8 run_tests lint
 
 install:
-	pip install -e .[dev]
+	pip install -e .[dev,devpy2,devpy3]
 
 release:
 	rm -rf build dist

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,10 @@ setuplib.setup(
             'pytest==3.0.6',
             'pytest-randomly==1.1.2',
         ],
-        'devpy2: python_version < "3.3"': [
+        'dev: python_version < "3.3"': [
             'mock==2.0.0',
         ],
-        'devpy3: python_version >= "3.3"': [
+        'dev: python_version >= "3.3"': [
             'mypy==0.501',
         ]
     }

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,15 @@ setuplib.setup(
     ],
     extras_require={
         'dev': [
-            'mock==2.0.0; python_version < "3.3"',
-            'mypy==0.501; python_version >= "3.3"',
             'pycodestyle==2.3.1',
             'pytest==3.0.6',
             'pytest-randomly==1.1.2',
+        ],
+        'devpy2: python_version < "3.3"': [
+            'mock==2.0.0',
+        ],
+        'devpy3: python_version >= "3.3"': [
+            'mypy==0.501',
         ]
     }
 )


### PR DESCRIPTION
The latest version of setuptools (36.2.0) introduced https://github.com/pypa/setuptools/pull/1085, which disallows the manner in which we were specifying environment markers, which broke a variety of env marker usages https://github.com/pypa/setuptools/issues/1087.

This PR properly specifies env markers.