### PR TITLE
Change release URLs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,12 +13,12 @@ To release a new version of [`shopify_python`](https://pypi.python.org/pypi/shop
         testpypi
 
     [testpypi]
-    repository = https://testpypi.python.org/pypi
+    repository = https://test.pypi.org/legacy/
     username = <your user name goes here>
     password = <your password goes here>
 
     [pypi]
-    repository = https://pypi.python.org/pypi
+    repository = https://upload.pypi.org/legacy/
     username = <your user name goes here>
     password = <your password goes here>
     ```


### PR DESCRIPTION
[There are new URLs to use](https://docs.python.org/3.6/distutils/packageindex.html#the-pypirc-file), the old ones return HTTP 401 when trying to use them (as demonstrated while trying to release [v0.4.1](https://github.com/Shopify/shopify_python/releases/tag/v0.4.1))