### PR TITLE
Add support for 'is'

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -131,7 +131,8 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         "==": "eq",
         "!=": "ne",
         ">=": "ge",
-        ">": "gt"
+        ">": "gt",
+        "is": "is"
     }
 
     def visit_assign(self, node):  # type: (astroid.Assign) -> None

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -274,7 +274,8 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         ('x == y', 'eq'),
         ('x != y', 'ne'),
         ('x >= y', 'ge'),
-        ('x > y', 'gt')
+        ('x > y', 'gt'),
+        ('x is y', 'is')
     ])
     def test_binary_lambda_func(self, test_case):
         (expression, op_name) = test_case


### PR DESCRIPTION
Fixes exception on the `is` keyword (https://github.com/Shopify/shopify_python/issues/77) by adding it to the list of operators.