### PR TITLE
Increase version number to 0.4.2

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
Let's cut a bugfix release that includes these bugfixes:
  - Add support for 'is' keyword https://github.com/Shopify/shopify_python/pull/79