### PR TITLE
Fix lambda_func and operators

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -121,18 +121,26 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
     BINARY_OPERATORS = {
         "+": "add",
-        "-": "sub",
-        "*": "mul",
+        "in": "contains",
         "/": "truediv",
+        "//": "floordiv",
+        "&": "and_",
+        "^": "xor",
+        "|": "or_",
         "**": "pow",
+        "is": "is",
+        "is not": "is_not",
+        "<<": "lshift",
         "%": "modulo",
+        "*": "mul",
+        ">>": "rshift",
+        "-": "sub",
         "<": "lt",
         "<=": "le",
         "==": "eq",
         "!=": "ne",
         ">=": "ge",
-        ">": "gt",
-        "is": "is"
+        ">": "gt"
     }
 
     def visit_assign(self, node):  # type: (astroid.Assign) -> None

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -297,7 +297,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         if isinstance(node.body, astroid.UnaryOp):
             operator = self.UNARY_OPERATORS[node.body.op]
             argname = node.args.args[0].name
-            if operator and not isinstance(node.body.operand, astroid.BinOp) and argname is node.body.operand.name:
+            if operator and hasattr(node.body.operand, 'name') and argname == node.body.operand.name:
                 varname = node.body.operand.name
                 lambda_fun = "lambda " + varname + ": " + node.body.op + " " + varname
                 op_fun = "operator." + operator

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -295,7 +295,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         """Prefer Operator Function to Lambda Functions"""
 
         if isinstance(node.body, astroid.UnaryOp):
-            operator = self.UNARY_OPERATORS[node.body.op]
+            operator = self.UNARY_OPERATORS.get(node.body.op)
             argname = node.args.args[0].name
             if operator and hasattr(node.body.operand, 'name') and argname == node.body.operand.name:
                 varname = node.body.operand.name
@@ -305,7 +305,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         elif isinstance(node.body, astroid.BinOp):
             if shopify_python.ast.count_tree_size(node.body) == 3 and len(node.args.args) == 2:
                 node = node.body
-                operator = self.BINARY_OPERATORS[node.op]
+                operator = self.BINARY_OPERATORS.get(node.op)
                 if operator:
                     left = str(node.left.value) if node.left.name == 'int' else node.left.name
                     right = str(node.right.value) if node.right.name == 'int' else node.right.name
@@ -315,7 +315,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         elif isinstance(node.body, astroid.Compare):
             if shopify_python.ast.count_tree_size(node.body) == 3 and len(node.args.args) == 2:
                 node = node.body
-                operator = self.BINARY_OPERATORS[node.ops[0][0]]
+                operator = self.BINARY_OPERATORS.get(node.ops[0][0])
                 if operator:
                     left = str(node.left.value) if node.left.name == 'int' else node.left.name
                     right = node.ops[0][1].name

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -241,6 +241,35 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.walk(unary_root)
 
+    def test_unary_lambda_func_without_operand_name_allowed(self):
+        unary_root = astroid.builder.parse("""
+        def unaryfnc():
+            unary_pass = map(lambda x: not x.attribute, [1, 2, 3, 4])
+        """)
+        with self.assertNoMessages():
+            self.walk(unary_root)
+
+    def test_unary_lambda_func_with_unknown_operator_allowed(self, monkeypatch):
+        monkeypatch.setattr(google_styleguide.GoogleStyleGuideChecker, 'UNARY_OPERATORS', dict())
+        unary_root = astroid.builder.parse("""
+        def unaryfnc():
+            unary_pass = map(lambda x: not x, [1, 2, 3, 4])
+        """)
+        with self.assertNoMessages():
+            self.walk(unary_root)
+
+    @pytest.mark.parametrize('operator', [
+        '+', '<'
+    ])
+    def test_binary_lambda_func_with_unknown_operator_allowed(self, operator, monkeypatch):
+        monkeypatch.setattr(google_styleguide.GoogleStyleGuideChecker, 'BINARY_OPERATORS', dict())
+        unary_root = astroid.builder.parse("""
+        def unaryfnc():
+            binary_pass = map(lambda x, y: x %s y, [(1, 2), (3, 4)])
+        """ % operator)
+        with self.assertNoMessages():
+            self.walk(unary_root)
+
     @pytest.mark.parametrize('test_case', [
         ('- x', 'neg'),
         ('~ x', 'invert'),

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -8,7 +8,7 @@ import pytest
 from shopify_python import google_styleguide
 
 
-class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):
+class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: disable=too-many-public-methods
 
     CHECKER_CLASS = google_styleguide.GoogleStyleGuideChecker
 


### PR DESCRIPTION
### Problem

We're [missing a few binary operators](https://docs.python.org/2/library/operator.html#mapping-operators-to-functions) and there are a few situations when `node.body.operand` doesn't have a name during the check for whether we can use an operator function as opposed to a lambda function, e.g.:

Linting `lambda key: not type_allowed(key._type)` throws
```
if operator and not isinstance(node.body.operand, astroid.BinOp) and argname is node.body.operand.name:
17 AttributeError: 'Call' object has no attribute 'name'
```

Linting `lambda key: not self.OUTPUT[key]["nullable"]` throws
```
if operator and not isinstance(node.body.operand, astroid.BinOp) and argname is node.body.operand.name:
17 AttributeError: 'Subscript' object has no attribute 'name'
```

Linting `lambda job: not job.is_loader` throws
```
if operator and not isinstance(node.body.operand, astroid.BinOp) and argname is node.body.operand.name:
17 AttributeError: 'Attribute' object has no attribute 'name'
```

### Solution
This PR:
  - Adds some of the missing binary operators and reorders them to better match [this list](https://docs.python.org/2/library/operator.html#mapping-operators-to-functions),
  - Makes the operator check optional by calling `get` on the dictionary of them to prevent future exceptions from being thrown (resulting in potential false negatives for operators that aren't included, bugs can be reported to add them)
  - Checks to ensure that the operand has a name before trying to use its name to prevent exceptions