### PR TITLE
Increase version number to 0.4.3

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
Let's cut a bugfix release that includes:
  - Fix lambda_func and operators (https://github.com/Shopify/shopify_python/pull/83)
