### PR TITLE
Check for blank line after a class definition

### DIFF
--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -331,11 +331,14 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
 
     def __class_def_check(self, node):  # type: (astroid.ClassDef) -> None
         """Enforce a blank line after a class definition line."""
-        if isinstance(node, astroid.ClassDef):
-            class_def_line = node.lineno
-            for next_def in node.body:
-                if isinstance(next_def, astroid.FunctionDef):
-                    next_line = next_def.lineno
-                    if next_line - class_def_line < 2:
-                        self.add_message('blank-line-after-class-required', node=node)
-                    break
+        prev_line = node.lineno
+
+        for element in node.body:
+            curr_line = element.lineno
+            blank_lines = curr_line - prev_line - 1
+            if isinstance(element, astroid.FunctionDef) and blank_lines < 1:
+                self.add_message('blank-line-after-class-required', node=node)
+                break
+            elif isinstance(element, astroid.FunctionDef):
+                break
+            prev_line = curr_line

--- a/tests/functional/blank_line_after_class_required.py
+++ b/tests/functional/blank_line_after_class_required.py
@@ -1,0 +1,5 @@
+# pylint:disable=missing-docstring,invalid-name,too-few-public-methods
+class SomeClass(object):
+
+    def apply(self):
+        pass

--- a/tests/functional/blank_line_after_class_required.py
+++ b/tests/functional/blank_line_after_class_required.py
@@ -1,5 +1,4 @@
 # pylint:disable=missing-docstring,invalid-name,too-few-public-methods
-class SomeClass(object):
-
+class SomeClass(object):  # [blank-line-after-class-required]
     def apply(self):
         pass

--- a/tests/functional/blank_line_after_class_required.txt
+++ b/tests/functional/blank_line_after_class_required.txt
@@ -1,1 +1,1 @@
-blank-line-after-class-required:2::No blank line after a class definition
+blank-line-after-class-required:2:SomeClass:No blank line after a class definition

--- a/tests/functional/blank_line_after_class_required.txt
+++ b/tests/functional/blank_line_after_class_required.txt
@@ -1,0 +1,1 @@
+blank-line-after-class-required:2::No blank line after a class definition

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -332,3 +332,31 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
         """.format(expression))
         with self.assertNoMessages():
             self.walk(binary_root)
+
+    def test_class_def_blank_line(self):
+        root = astroid.builder.parse("""
+            class SomePipeline(object):
+                def apply(content):
+                    return content.withColumn('zero', F.lit(0.0))
+            """)
+        with self.assertAddsMessages(
+                *[pylint.testutils.Message('blank-line-after-class-required', node=root.body[0])]
+        ):
+            self.walk(root)
+
+        with self.assertNoMessages():
+            self.walk(astroid.builder.parse("""
+            class SomePipeline(object):
+
+                def apply(content):
+                    return content.withColumn('zero', F.lit(0.0))
+
+            class FirstStage(object):
+                pass
+
+            class SecondStage(object):
+                INPUTS = {}
+                OUTPUTS = {}
+                def apply():
+                    pass
+            """))

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -340,7 +340,7 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
                     return content.withColumn('zero', F.lit(0.0))
             """)
         with self.assertAddsMessages(
-                *[pylint.testutils.Message('blank-line-after-class-required', node=root.body[0])]
+            *[pylint.testutils.Message('blank-line-after-class-required', node=root.body[0])]
         ):
             self.walk(root)
 

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -338,9 +338,23 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
             class SomePipeline(object):
                 def apply(content):
                     return content.withColumn('zero', F.lit(0.0))
+
+            class Fact(object):
+                INPUTS = {}
+                def apply(self):
+                    pass
+
+            class Stage(object):
+                INPUTS = {}
+
+                OUTPUTS = {}
+                def apply(self):
+                    pass
             """)
         with self.assertAddsMessages(
-            *[pylint.testutils.Message('blank-line-after-class-required', node=root.body[0])]
+            *[pylint.testutils.Message('blank-line-after-class-required', node=root.body[0]),
+              pylint.testutils.Message('blank-line-after-class-required', node=root.body[1]),
+              pylint.testutils.Message('blank-line-after-class-required', node=root.body[2])]
         ):
             self.walk(root)
 
@@ -357,6 +371,10 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
             class SecondStage(object):
                 INPUTS = {}
                 OUTPUTS = {}
+
+                def check():
+                    pass
+
                 def apply():
                     pass
             """))


### PR DESCRIPTION
Detect missing blank line after a class definition. (moved from starscream specific linter as suggested in https://github.com/Shopify/starscream/pull/21070)