### PR TITLE
Fix the crash on Autopep8 breaking change 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
    - "3.3"
    - "3.4"
    - "3.5"
+   - "3.6"
 before_install:
   - pip install -U pip setuptools
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
 language: python
 python:
    - "2.7"
-   - "3.3"
    - "3.4"
    - "3.5"
    - "3.6"

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuplib.setup(
         'astroid>=1.5,<1.6',
         'six>=1.10.0,<2',
         'typing>=3.5.3.0,<4',
-        'autopep8>=1.2.2,<2',
+        'autopep8>=1.3.4,<2',
     ],
     extras_require={
         'dev': [

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -78,6 +78,7 @@ _AutopepOptions = typing.NamedTuple('_AutopepOptions', [  # pylint: disable=glob
     ('recursive', bool),
     ('select', typing.Set[str]),
     ('verbose', int),
+    ('hang_closing', bool),
 ])
 
 
@@ -100,7 +101,8 @@ def autopep_files(files, max_line_length):
                               pep8_passes=-1,
                               recursive=False,
                               select={'W', 'E'},
-                              verbose=0)
+                              verbose=0,
+                              hang_closing=False)
     autopep8.fix_multiple_files(files, options, sys.stdout)
 
 


### PR DESCRIPTION
Fix the crash by providing the options `hang-closing` now required by Autopep8.

This option is actually passed to **pycodestyle**: 

```
  --hang-closing       hang closing bracket instead of matching indentation of
                       opening bracket's line
```
See http://pycodestyle.pycqa.org/en/latest/intro.html

- Note 1: This PR **disables** this `hang-closing` option. ([discussion](https://github.com/PyCQA/pycodestyle/issues/103))
- Note 2: the commit to add tests in Py3.6 is here to trigger the CI and highlight the crash.

Resolves #90