### PR TITLE
Release v0.4.4

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
Maintenance release:

- Check for blank line after a class definition #86
- bump GitPython to 2.1.8 #87 
- Astroid less than 1.6 #89 
- Fix the crash on Autopep8 breaking change #91 