### PR TITLE
Upgrade to pylint 1.8.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,7 @@ setuplib.setup(
     test_suite='tests',
     install_requires=[
         'GitPython>=2.1.8,<3',
-        'pylint>=1.7.1,<1.8',
-        'astroid>=1.5,<1.6',
+        'pylint>=1.8.4,<1.9',
         'six>=1.10.0,<2',
         'typing>=3.5.3.0,<4',
         'autopep8>=1.3.4,<2',


### PR DESCRIPTION
__Description__

We've previously fixed the version of `pylint` to `1.7.1` (https://github.com/Shopify/shopify_python/pull/69) cause it seems there was an issue with `astroid` >= 1.6.0`. This doesn't seems to be the case anymore and it should be safe to migrate to the latest stable release.



