### PR TITLE
Better Dev support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ run_tests: clean
 test: autopep8 run_tests lint
 
 install:
-	pip install -e .[dev]
+	pip install -e .
+	pip install -r requirements.txt
 
 release:
 	rm -rf build dist

--- a/dev.yml
+++ b/dev.yml
@@ -14,5 +14,4 @@ commands:
     run: make lint
   test:
     desc: "Run all tests"
-    run: make test
-
+    run: make run_tests

--- a/dev.yml
+++ b/dev.yml
@@ -3,11 +3,10 @@ name: shopify-python
 type: python
 
 up:
-  - python: 3.6.1
-  - custom:
-      name: "link development shopify-python as a package"
-      met?: "pip show shopify-python | grep \"Location: $(pwd)\" 1>/dev/null"
-      meet: "pip install -e .[dev]"
+  - python: 3.6.5
+  - python_develop
+  - pip: [requirements.txt]
+
 commands:
   lint:
     desc: "Check for Python style & syntax errors in all Python files"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pycodestyle==2.3.1
+pytest==3.0.6
+pytest-randomly==1.1.2
+
+mock==2.0.0  ; python_version < "3.3"
+mypy==0.501  ; python_version >= "3.3"

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,7 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 import re
 
-try:
-    import setuptools as setuplib
-except ImportError:
-    import distutils.core as setuplib
+import setuptools
 
 
 def get_version():
@@ -18,7 +15,7 @@ def get_version():
     return version
 
 
-setuplib.setup(
+setuptools.setup(
     name='shopify_python',
     version=get_version(),
     description='Python Standards Library for Shopify',

--- a/setup.py
+++ b/setup.py
@@ -42,18 +42,5 @@ setuptools.setup(
         'six>=1.10.0,<2',
         'typing>=3.5.3.0,<4',
         'autopep8>=1.3.4,<2',
-    ],
-    extras_require={
-        'dev': [
-            'pycodestyle==2.3.1',
-            'pytest==3.0.6',
-            'pytest-randomly==1.1.2',
-        ],
-        'dev: python_version < "3.3"': [
-            'mock==2.0.0',
-        ],
-        'dev: python_version >= "3.3"': [
-            'mypy==0.501',
-        ]
-    }
+    ]
 )


### PR DESCRIPTION
## Why

Resuming work on ShopifyPython is not easy without a proper dev setup.

## How

- move the dev requirements from extra_require to a pip requirements file
- make Dev install the dev requirements
- make Dev install the project in develop mode 
