### PR TITLE
Improve readability for deps in setuptools install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ setuptools.setup(
     ],
     test_suite='tests',
     install_requires=[
-        'GitPython>=2.1.8,<3',
-        'pylint>=1.7.1,<1.8',
-        'astroid>=1.5,<1.6',
-        'six>=1.10.0,<2',
-        'typing>=3.5.3.0,<4',
-        'autopep8>=1.3.4,<2',
+        'GitPython >= 2.1.8, < 3',
+        'pylint ~= 1.7.1',
+        'astroid ~= 1.5.3',
+        'six ~= 1.10',
+        'typing ~= 3.5 ; python_version < "3.5"',  # In Python 3.5+ the typing module lives in the stdlib
+        'autopep8 ~= 1.3.4',
     ]
 )


### PR DESCRIPTION
- Improve readability in install_requires with the [compatible-release](https://www.python.org/dev/peps/pep-0440/#compatible-release) constraints.
- Don't install `typing` when not needed