### PR TITLE
Upgrade to Pylint 2

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -36,7 +36,9 @@ load-plugins=shopify_python
 # CHANGED:
 # missing-docstring: docstrings should be optional
 # redefined-outer-name: doesn't play well with pytest fixtures
-disable=missing-docstring,redefined-outer-name
+# bad-continuation: PyLint 2.0 fixes expected indentation of wrapped `with` lines. Disable this rule to avoid triggering
+#     false errors in PyLint 1.9.
+disable=missing-docstring,redefined-outer-name,bad-continuation
 
 
 [REPORTS]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ pycodestyle==2.3.1
 pytest==3.0.6
 pytest-randomly==1.1.2
 
-mock==2.0.0  ; python_version < "3.3"
+mock==2.0.0
 mypy==0.501  ; python_version >= "3.3"

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setuptools.setup(
     test_suite='tests',
     install_requires=[
         'GitPython~=2.1.11',
-        'pylint~=2.1.1',
+        'pylint~=2.1.1;python_version>="3.0"',
+        'pylint~=1.9.3;python_version<"3.0"',
         'typing~=3.6.6',
         'autopep8~=1.4',
     ]

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,9 @@ setuptools.setup(
     ],
     test_suite='tests',
     install_requires=[
-        'GitPython >= 2.1.8, < 3',
-        'pylint ~= 1.7.1',
-        'astroid ~= 1.5.3',
-        'six ~= 1.10',
-        'typing ~= 3.5 ; python_version < "3.5"',  # In Python 3.5+ the typing module lives in the stdlib
-        'autopep8 ~= 1.3.4',
+        'GitPython~=2.1.11',
+        'pylint~=2.1.1',
+        'typing~=3.6.6',
+        'autopep8~=1.4',
     ]
 )

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.4.5'
+__version__ = '0.5.0'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -125,6 +125,6 @@ def pylint_files(files, **kwargs):
     pylint_args = ["--{}={}".format(key, value) for key, value in kwargs.items()]
 
     reporter = _CustomPylintReporter()
-    lint.Run(files + pylint_args, exit=False, reporter=reporter)
+    lint.Run(files + pylint_args, do_exit=False, reporter=reporter)
 
     return reporter.raw_messages

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -37,15 +37,15 @@ def _file_is_python(path):
     # type: (str) -> bool
     if path.endswith('.py'):
         return True
-    else:
-        _, extension = os.path.splitext(path)
-        if not extension:
-            try:
-                with open(path) as might_be_python:
-                    line = might_be_python.readline()
-                    return line.startswith('#!') and 'python' in line
-            except UnicodeDecodeError:
-                pass
+
+    _, extension = os.path.splitext(path)
+    if extension:
+        return False
+    try:
+        with open(path) as might_be_python:
+            line = might_be_python.readline()
+            return line.startswith('#!') and 'python' in line
+    except UnicodeDecodeError:
         return False
 
 
@@ -128,8 +128,8 @@ def pylint_files(files, **kwargs):
     reporter = _CustomPylintReporter()
     pylint_version = int(pylint.__version__.split('.')[0])
     if pylint_version < 2:
-        lint.Run(files + pylint_args, exit=False, reporter=reporter)
+        lint.Run(files + pylint_args, exit=False, reporter=reporter)  # pylint: disable=unexpected-keyword-arg
     else:
-        lint.Run(files + pylint_args, do_exit=False, reporter=reporter)
+        lint.Run(files + pylint_args, do_exit=False, reporter=reporter)  # pylint: disable=unexpected-keyword-arg
 
     return reporter.raw_messages

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -4,6 +4,7 @@ import typing  # pylint: disable=unused-import
 import autopep8
 from git import repo
 from git.refs import head  # pylint: disable=unused-import
+import pylint
 from pylint import lint
 from pylint import utils  # pylint: disable=unused-import
 from pylint.reporters import text
@@ -125,6 +126,10 @@ def pylint_files(files, **kwargs):
     pylint_args = ["--{}={}".format(key, value) for key, value in kwargs.items()]
 
     reporter = _CustomPylintReporter()
-    lint.Run(files + pylint_args, do_exit=False, reporter=reporter)
+    pylint_version = int(pylint.__version__.split('.')[0])
+    if pylint_version < 2:
+        lint.Run(files + pylint_args, exit=False, reporter=reporter)
+    else:
+        lint.Run(files + pylint_args, do_exit=False, reporter=reporter)
 
     return reporter.raw_messages

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -2,13 +2,14 @@ import re
 import typing  # pylint: disable=unused-import
 
 import astroid  # pylint: disable=unused-import
-import shopify_python.ast
-import six
 
 from pylint import checkers
 from pylint import interfaces
 from pylint import lint  # pylint: disable=unused-import
-from pylint import utils
+
+import six
+
+import shopify_python.ast
 
 
 def register_checkers(linter):  # type: (lint.PyLinter) -> None
@@ -149,7 +150,7 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
     def __init__(self, linter):
         super(GoogleStyleGuideChecker, self).__init__(linter)
         name_checker = checkers.base.NameChecker(linter)
-        (regexps, _) = name_checker._create_naming_rules()
+        (regexps, _) = name_checker._create_naming_rules()  # pylint: disable=protected-access
         self.__class_regexp = regexps['class']
         self.__const_regexp = regexps['const']
 

--- a/shopify_python/google_styleguide.py
+++ b/shopify_python/google_styleguide.py
@@ -146,6 +146,13 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         ">": "gt"
     }
 
+    def __init__(self, linter):
+        super(GoogleStyleGuideChecker, self).__init__(linter)
+        name_checker = checkers.base.NameChecker(linter)
+        (regexps, _) = name_checker._create_naming_rules()
+        self.__class_regexp = regexps['class']
+        self.__const_regexp = regexps['const']
+
     def visit_assign(self, node):  # type: (astroid.Assign) -> None
         self.__avoid_global_variables(node)
 
@@ -221,11 +228,11 @@ class GoogleStyleGuideChecker(checkers.BaseChecker):
         """Avoid global variables."""
 
         def check_assignment(node):
-            if utils.get_global_option(self, 'class-rgx').match(node.name):
+
+            if self.__class_regexp.match(node.name):
                 return  # Type definitions are allowed if they assign to a class name
 
-            if utils.get_global_option(self, 'const-rgx').match(node.name) or \
-               re.match('^__[a-z]+__$', node.name):
+            if self.__const_regexp.match(node.name) or re.match('^__[a-z]+__$', node.name):
                 return  # Constants are allowed
 
             self.add_message('global-variable', node=node, args={'name': node.name})

--- a/tests/functional/blank_line_after_class_required.py
+++ b/tests/functional/blank_line_after_class_required.py
@@ -1,4 +1,4 @@
-# pylint:disable=missing-docstring,invalid-name,too-few-public-methods
+# pylint:disable=missing-docstring,invalid-name,too-few-public-methods,useless-object-inheritance
 class SomeClass(object):  # [blank-line-after-class-required]
     def apply(self):
         pass

--- a/tests/functional/blank_line_after_class_required.py
+++ b/tests/functional/blank_line_after_class_required.py
@@ -1,4 +1,4 @@
-# pylint:disable=missing-docstring,invalid-name,too-few-public-methods,useless-object-inheritance
-class SomeClass(object):  # [blank-line-after-class-required]
-    def apply(self):
+# pylint:disable=missing-docstring,invalid-name,too-few-public-methods,old-style-class
+class SomeClass:  # [blank-line-after-class-required]
+    def __init__(self):
         pass

--- a/tests/functional/global_variable.py
+++ b/tests/functional/global_variable.py
@@ -1,4 +1,4 @@
-# pylint: disable=invalid-name,too-few-public-methods,missing-docstring,unpacking-non-sequence,undefined-variable
+# pylint: disable=invalid-name,too-few-public-methods,missing-docstring,unpacking-non-sequence,undefined-variable,useless-object-inheritance
 
 my_int = 77  # [global-variable]
 

--- a/tests/functional/global_variable.py
+++ b/tests/functional/global_variable.py
@@ -1,9 +1,13 @@
-# pylint: disable=invalid-name,too-few-public-methods,missing-docstring,unpacking-non-sequence,undefined-variable,useless-object-inheritance
+# pylint: disable=invalid-name,too-few-public-methods,missing-docstring,unpacking-non-sequence,undefined-variable,old-style-class
 
 my_int = 77  # [global-variable]
 
 
-class Integers(object):
+class Integers:
+
+    def __init__(self):
+        pass
+
     one = 1
     two = 2
     three = 3
@@ -26,5 +30,9 @@ Point = namedtuple('Point', ['x', 'y'])
 _Point = namedtuple('_Point', ['x', 'y'])
 
 
-class MyClass(object):
+class MyClass:
+
+    def __init__(self):
+        pass
+
     class_var = 10

--- a/tests/functional/global_variable.py
+++ b/tests/functional/global_variable.py
@@ -1,4 +1,5 @@
-# pylint: disable=invalid-name,too-few-public-methods,missing-docstring,unpacking-non-sequence,undefined-variable,old-style-class
+# pylint: disable=invalid-name,too-few-public-methods,missing-docstring,unpacking-non-sequence,undefined-variable
+# pylint: disable=old-style-class
 
 my_int = 77  # [global-variable]
 

--- a/tests/functional/global_variable.txt
+++ b/tests/functional/global_variable.txt
@@ -1,4 +1,4 @@
 global-variable:3::my_int declared at the module level (i.e. global)
-global-variable:14::module_var declared at the module level (i.e. global)
-global-variable:14::other_module_var declared at the module level (i.e. global)
-global-variable:16::another_module_var declared at the module level (i.e. global)
+global-variable:18::module_var declared at the module level (i.e. global)
+global-variable:18::other_module_var declared at the module level (i.e. global)
+global-variable:20::another_module_var declared at the module level (i.e. global)

--- a/tests/functional/global_variable.txt
+++ b/tests/functional/global_variable.txt
@@ -1,4 +1,4 @@
-global-variable:3::my_int declared at the module level (i.e. global)
-global-variable:18::module_var declared at the module level (i.e. global)
-global-variable:18::other_module_var declared at the module level (i.e. global)
-global-variable:20::another_module_var declared at the module level (i.e. global)
+global-variable:4::my_int declared at the module level (i.e. global)
+global-variable:19::module_var declared at the module level (i.e. global)
+global-variable:19::other_module_var declared at the module level (i.e. global)
+global-variable:21::another_module_var declared at the module level (i.e. global)

--- a/tests/functional/two_arg_exception3.txt
+++ b/tests/functional/two_arg_exception3.txt
@@ -1,1 +1,1 @@
-syntax-error:5::invalid syntax (<string>, line 5)
+syntax-error:5::invalid syntax (<unknown>, line 5)

--- a/tests/shopify_python/test_google_styleguide.py
+++ b/tests/shopify_python/test_google_styleguide.py
@@ -40,8 +40,8 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
             'other_nonexistent_package.nonexistent_module',
         ]
         with self.assertAddsMessages(*[
-            pylint.testutils.Message('import-modules-only', node=node, args={'child': child})
-            for node, child in zip(import_nodes, tried_to_import)
+                pylint.testutils.Message('import-modules-only', node=node, args={'child': child})
+                for node, child in zip(import_nodes, tried_to_import)
         ]):
             self.walk(root)
 
@@ -62,10 +62,10 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
         from .. import string, os
         """)
         with self.assert_adds_code_messages(
-            ['import-full-path'],
-            pylint.testutils.Message('import-full-path', node=root.body[0], args={'module': '.string'}),
-            pylint.testutils.Message('import-full-path', node=root.body[1], args={'module': '.string'}),
-            pylint.testutils.Message('import-full-path', node=root.body[1], args={'module': '.os'}),
+                ['import-full-path'],
+                pylint.testutils.Message('import-full-path', node=root.body[0], args={'module': '.string'}),
+                pylint.testutils.Message('import-full-path', node=root.body[1], args={'module': '.string'}),
+                pylint.testutils.Message('import-full-path', node=root.body[1], args={'module': '.os'}),
         ):
             self.walk(root)
 
@@ -82,12 +82,12 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
             class_var = 10
         """)
         with self.assertAddsMessages(
-            pylint.testutils.Message(
-                'global-variable', node=root.body[0].targets[0].elts[0], args={'name': 'module_var'}),
-            pylint.testutils.Message(
-                'global-variable', node=root.body[0].targets[0].elts[1], args={'name': 'other_module_var'}),
-            pylint.testutils.Message(
-                'global-variable', node=root.body[1].targets[0], args={'name': 'another_module_var'}),
+                pylint.testutils.Message(
+                    'global-variable', node=root.body[0].targets[0].elts[0], args={'name': 'module_var'}),
+                pylint.testutils.Message(
+                    'global-variable', node=root.body[0].targets[0].elts[1], args={'name': 'other_module_var'}),
+                pylint.testutils.Message(
+                    'global-variable', node=root.body[1].targets[0], args={'name': 'another_module_var'}),
         ):
             self.walk(root)
 
@@ -160,9 +160,9 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
         try_finally = root.body[0]
         try_except = try_finally.body[0]
         with self.assertAddsMessages(
-            pylint.testutils.Message('finally-too-long', node=try_finally, args={'found': 24}),
-            pylint.testutils.Message('try-too-long', node=try_except, args={'found': 28}),
-            pylint.testutils.Message('except-too-long', node=try_except.handlers[0], args={'found': 39}),
+                pylint.testutils.Message('finally-too-long', node=try_finally, args={'found': 24}),
+                pylint.testutils.Message('try-too-long', node=try_except, args={'found': 28}),
+                pylint.testutils.Message('except-too-long', node=try_except.handlers[0], args={'found': 39}),
         ):
             self.walk(root)
 
@@ -352,9 +352,9 @@ class TestGoogleStyleGuideChecker(pylint.testutils.CheckerTestCase):  # pylint: 
                     pass
             """)
         with self.assertAddsMessages(
-            *[pylint.testutils.Message('blank-line-after-class-required', node=root.body[0]),
-              pylint.testutils.Message('blank-line-after-class-required', node=root.body[1]),
-              pylint.testutils.Message('blank-line-after-class-required', node=root.body[2])]
+                *[pylint.testutils.Message('blank-line-after-class-required', node=root.body[0]),
+                  pylint.testutils.Message('blank-line-after-class-required', node=root.body[1]),
+                  pylint.testutils.Message('blank-line-after-class-required', node=root.body[2])]
         ):
             self.walk(root)
 

--- a/tests/shopify_python/test_shopify_styleguide.py
+++ b/tests/shopify_python/test_shopify_styleguide.py
@@ -21,7 +21,7 @@ class TestShopifyStyleGuideChecker(pylint.testutils.CheckerTestCase):
         setattr(self.linter, 'msgs_store', mock_msgs_store)
 
         # Create tokens
-        tokens = pylint.testutils.tokenize_str("""
+        tokens = pylint.testutils._tokenize_str("""
         import os  # pylint: disable=unused-import
         import os  # pylint: disable=unused-import,W0611
         import os  # pylint: disable=W0611,C0302,C0303

--- a/tests/shopify_python/test_shopify_styleguide.py
+++ b/tests/shopify_python/test_shopify_styleguide.py
@@ -1,9 +1,5 @@
+import mock
 import pylint.testutils
-
-try:
-    import unittest.mock as mock  # Python 3.3+
-except ImportError:
-    import mock  # Python < 3.3
 
 from shopify_python import shopify_styleguide
 
@@ -21,7 +17,8 @@ class TestShopifyStyleGuideChecker(pylint.testutils.CheckerTestCase):
         setattr(self.linter, 'msgs_store', mock_msgs_store)
 
         # Create tokens
-        tokens = pylint.testutils._tokenize_str("""
+        tokens = pylint.testutils._tokenize_str(  # pylint: disable=protected-access
+            """
         import os  # pylint: disable=unused-import
         import os  # pylint: disable=unused-import,W0611
         import os  # pylint: disable=W0611,C0302,C0303
@@ -47,8 +44,8 @@ class TestShopifyStyleGuideChecker(pylint.testutils.CheckerTestCase):
 
         # Test
         with self.assertAddsMessages(*[
-            pylint.testutils.Message('disable-name-only', line=line, args={'code': code, 'name': 'mocked'})
-            for line, code in expected_line_msgcodes
+                pylint.testutils.Message('disable-name-only', line=line, args={'code': code, 'name': 'mocked'})
+                for line, code in expected_line_msgcodes
         ]):
             self.checker.process_tokens(tokens)
         mock_msgs_store.get_msg_display_string.assert_has_calls(


### PR DESCRIPTION
Pylint 2 seems to be a major overhaul. This PR fixes a few migration issues that arise.

It relies on some "private" parts of Pylint. I suggest that we should accept this for now but it would be appropriate to open a discussion with the maintainers about how to appropriately expose what we are looking for. I bumped the minor version number because it would seem that forcing clients to upgrade to a new version of Pylint is not really appropriate for a patch release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shopify/shopify_python/102)
<!-- Reviewable:end -->
