### PR TITLE
A more reliable way of having dependencies based on python_version.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,16 @@ setuptools.setup(
     test_suite='tests',
     install_requires=[
         'GitPython~=2.1.11',
-        'pylint~=2.1.1;python_version>="3.0"',
-        'pylint~=1.9.3;python_version<"3.0"',
         'typing~=3.6.6',
         'autopep8~=1.4',
-    ]
+    ],
+    extras_require={
+        ':python_version>="3.0"': [
+            'pylint~=2.1.1'
+        ],
+        ':python_version<"3.0"': [
+            'pylint~=1.9.3'
+        ]
+    }
+
 )


### PR DESCRIPTION
After pushing to test PyPi, I found that when installed in Python3 the library would install PyLint 2.1.1 but it would also try (and fail) to install 1.9.3.

 I traced it to an apparent bug in `wheel`, described here: https://github.com/inveniosoftware/troubleshooting/issues/1

Although some people imply that upgrading my build tools would also fix it, it seems more prudent to pick a mechanism that will work even if another maintainer happens to have a similar setup to mine (since there is nothing in the release steps that ensures that your pip/wheel/etc. are up-to-date).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shopify/shopify_python/103)
<!-- Reviewable:end -->
