### PR TITLE
Bump version due to failed release in test PyPi.

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
I had to bump this because my original release of 0.5.0 (only ever uploaded to test PyPi) was broken and you cannot reuse a version even in the test repo.

I took the liberty of pushing the release already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shopify/shopify_python/104)
<!-- Reviewable:end -->
