### PR TITLE
Include typing marker for mypy (PEP-561).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pycodestyle==2.3.1
+pycodestyle~=2.4
 pytest==3.0.6
 pytest-randomly==1.1.2
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setuptools.setup(
     license='MIT',
     packages=['shopify_python'],
     include_package_data=True,
+    package_data={'shopify_python': ['py.typed']},  # PEP-561: typing marker for MyPy
     zip_safe=False,
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.5.1'
+__version__ = '0.5.2'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
## Description

When using `mypy`, to better deal with typing from dependent packages we need to "advertise" our support of typing. As it it describe at https://www.python.org/dev/peps/pep-0561/#packaging-type-information, if you want `mypy` to check for correct typing of dependant package and be able to ignore specific ones that don't support it, you need to add a specific marker in your `setup.py`.

## How does this PR work?

This PR is adding the typing marker to the setup.py