### PR TITLE
Added methods for getting untracked and uncommitted python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 *.egg-info
 .DS_Store
 .cache
-# ignore pycharm config files
 .idea
 build/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.egg-info
 .DS_Store
 .cache
+# ignore pycharm config files
+.idea
 build/
 dist/

--- a/pylintrc
+++ b/pylintrc
@@ -38,7 +38,7 @@ load-plugins=shopify_python
 # redefined-outer-name: doesn't play well with pytest fixtures
 # bad-continuation: PyLint 2.0 fixes expected indentation of wrapped `with` lines. Disable this rule to avoid triggering
 #     false errors in PyLint 1.9.
-disable=missing-docstring,redefined-outer-name,bad-continuation
+disable=missing-docstring,redefined-outer-name,bad-continuation,redefined-builtin
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -38,7 +38,7 @@ load-plugins=shopify_python
 # redefined-outer-name: doesn't play well with pytest fixtures
 # bad-continuation: PyLint 2.0 fixes expected indentation of wrapped `with` lines. Disable this rule to avoid triggering
 #     false errors in PyLint 1.9.
-disable=missing-docstring,redefined-outer-name,bad-continuation,redefined-builtin
+disable=missing-docstring,redefined-outer-name,bad-continuation
 
 
 [REPORTS]

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -64,10 +64,10 @@ def uncommitted_python_files(root_path):
     git_repo = repo.Repo(root_path)
     unstaged_files = [
         file.a_path for file in git_repo.index.diff(None) if _file_is_python(
-            file.a_path)] #pylint: disable=redefined-builtin
+            file.a_path)]
     staged_files = [
         file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(
-            file.a_path)] #pylint: disable=redefined-builtin
+            file.a_path)]
     return frozenset(unstaged_files + staged_files)
 
 

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -62,8 +62,8 @@ def changed_python_files_in_tree(root_path):
 def uncommitted_python_files(root_path):
     # type: (str) -> typing.FrozenSet[str]
     git_repo = repo.Repo(root_path)
-    unstaged_files = [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)]
-    staged_files = [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)]
+    unstaged_files = [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)] #pylint: disable=redefined-builtin
+    staged_files = [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)] #pylint: disable=redefined-builtin
     return frozenset(unstaged_files + staged_files)
 
 

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -62,14 +62,8 @@ def changed_python_files_in_tree(root_path):
 def uncommitted_python_files(root_path):
     # type: (str) -> typing.FrozenSet[str]
     git_repo = repo.Repo(root_path)
-    unstaged_files = []
-    staged_files = []
-    for file in git_repo.index.diff(None):
-        if _file_is_python(file.a_path):
-            unstaged_files.append(file.a_path)
-    for file in git_repo.index.diff('HEAD'):
-        if _file_is_python(file.a_path):
-            staged_files.append(file.a_path)
+    unstaged_files = [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)]
+    staged_files = [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)]
     return frozenset(unstaged_files + staged_files)
 
 

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -62,8 +62,14 @@ def changed_python_files_in_tree(root_path):
 def uncommitted_python_files(root_path):
     # type: (str) -> typing.FrozenSet[str]
     git_repo = repo.Repo(root_path)
-    unstaged_files = [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)]
-    staged_files = [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)]
+    unstaged_files = []
+    staged_files = []
+    for file in git_repo.index.diff(None):
+        if _file_is_python(file.a_path):
+            unstaged_files.append(file.a_path)
+    for file in git_repo.index.diff('HEAD'):
+        if _file_is_python(file.a_path):
+            staged_files.append(file.a_path)
     return frozenset(unstaged_files + staged_files)
 
 

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -62,12 +62,8 @@ def changed_python_files_in_tree(root_path):
 def uncommitted_python_files(root_path):
     # type: (str) -> typing.FrozenSet[str]
     git_repo = repo.Repo(root_path)
-    unstaged_files = [
-        file.a_path for file in git_repo.index.diff(None) if _file_is_python(
-            file.a_path)]
-    staged_files = [
-        file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(
-            file.a_path)]
+    unstaged_files = [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)]
+    staged_files = [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)]
     return frozenset(unstaged_files + staged_files)
 
 

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -64,19 +64,19 @@ def unstaged_python_files(root_path):
     # type: (str) -> typing.List[str]
     """Gets a list of paths of all uncommitted unstaged files in a given repository."""
     git_repo = repo.Repo(root_path)
-    return [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)]
+    return [changed_file.a_path for changed_file in git_repo.index.diff(None) if _file_is_python(changed_file.a_path)]
 
 
 def staged_python_files(root_path):
     # type: (str) -> typing.List[str]
     """Gets a list of paths of all uncommitted staged files in a given repository."""
     git_repo = repo.Repo(root_path)
-    return [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)]
+    return [changed_file.a_path for changed_file in git_repo.index.diff('HEAD') if _file_is_python(changed_file.a_path)]
 
 
 def untracked_python_files(root_path):
     # type: (str) -> typing.List[str]
-    """Gets a list of paths of all untracked files in a given repository"""
+    """Gets a list of paths of all untracked files in a given repository."""
     git_repo = repo.Repo(root_path)
     return [item for item in git_repo.untracked_files if _file_is_python(item)]
 

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -51,13 +51,26 @@ def _file_is_python(path):
 
 def changed_python_files_in_tree(root_path):
     # type: (str) -> typing.List[str]
-
     git_repo = repo.Repo(root_path)
     remote_master = _remote_origin_master(git_repo)
     modified = _modified_in_branch(git_repo, remote_master)
     abs_modified = [os.path.join(git_repo.working_dir, x) for x in modified]
     return [mod for (mod, abs_mod) in zip(modified, abs_modified)
             if os.path.exists(abs_mod) and os.path.isfile(abs_mod) and _file_is_python(abs_mod)]
+
+
+def uncommitted_python_files(root_path):
+    # type: (str) -> typing.FrozenSet[str]
+    git_repo = repo.Repo(root_path)
+    unstaged_files = [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)]
+    staged_files = [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)]
+    return frozenset(unstaged_files + staged_files)
+
+
+def untracked_python_files(root_path):
+    # type: (str) -> typing.List[str]
+    git_repo = repo.Repo(root_path)
+    return [item for item in git_repo.untracked_files if _file_is_python(item)]
 
 
 # Options are defined here: https://pypi.python.org/pypi/autopep8#usage

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -84,8 +84,9 @@ def untracked_python_files(root_path):
 def changed_local_python_files(root_path):
     # type: (str) -> typing.FrozenSet[str]
     """
-    Gets a list of paths of all changed files, including,
-    committed, uncommitted and untracked files in a given repository.
+    Gets a list of paths of all changed files.
+
+    This includes committed, uncommitted and untracked files in a given repository.
     """
     return frozenset(
         changed_python_files_in_tree(root_path) +

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -62,8 +62,12 @@ def changed_python_files_in_tree(root_path):
 def uncommitted_python_files(root_path):
     # type: (str) -> typing.FrozenSet[str]
     git_repo = repo.Repo(root_path)
-    unstaged_files = [file.a_path for file in git_repo.index.diff(None) if _file_is_python(file.a_path)] #pylint: disable=redefined-builtin
-    staged_files = [file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(file.a_path)] #pylint: disable=redefined-builtin
+    unstaged_files = [
+        file.a_path for file in git_repo.index.diff(None) if _file_is_python(
+            file.a_path)] #pylint: disable=redefined-builtin
+    staged_files = [
+        file.a_path for file in git_repo.index.diff('HEAD') if _file_is_python(
+            file.a_path)] #pylint: disable=redefined-builtin
     return frozenset(unstaged_files + staged_files)
 
 

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -51,7 +51,7 @@ def _file_is_python(path):
 
 def changed_python_files_in_tree(root_path):
     # type: (str) -> typing.List[str]
-    """Gets a list of paths of all committed files in a given repository."""
+    """Returns the list of all committed files in a given repository."""
     git_repo = repo.Repo(root_path)
     remote_master = _remote_origin_master(git_repo)
     modified = _modified_in_branch(git_repo, remote_master)
@@ -62,21 +62,21 @@ def changed_python_files_in_tree(root_path):
 
 def unstaged_python_files(root_path):
     # type: (str) -> typing.List[str]
-    """Gets a list of paths of all uncommitted unstaged files in a given repository."""
+    """Returns the list of all uncommitted unstaged files in a given repository."""
     git_repo = repo.Repo(root_path)
     return [changed_file.a_path for changed_file in git_repo.index.diff(None) if _file_is_python(changed_file.a_path)]
 
 
 def staged_python_files(root_path):
     # type: (str) -> typing.List[str]
-    """Gets a list of paths of all uncommitted staged files in a given repository."""
+    """Returns the list of all uncommitted staged files in a given repository."""
     git_repo = repo.Repo(root_path)
     return [changed_file.a_path for changed_file in git_repo.index.diff('HEAD') if _file_is_python(changed_file.a_path)]
 
 
 def untracked_python_files(root_path):
     # type: (str) -> typing.List[str]
-    """Gets a list of paths of all untracked files in a given repository."""
+    """Returns the list of all untracked files in a given repository."""
     git_repo = repo.Repo(root_path)
     return [item for item in git_repo.untracked_files if _file_is_python(item)]
 
@@ -84,7 +84,7 @@ def untracked_python_files(root_path):
 def changed_local_python_files(root_path):
     # type: (str) -> typing.FrozenSet[str]
     """
-    Gets a list of paths of all changed files.
+    Returns the list of all changed files.
 
     This includes committed, uncommitted and untracked files in a given repository.
     """

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -211,6 +211,15 @@ def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
 
 
+def test_committed_files(main_repo, python_file):
+    # type: (repo.Repo, str) -> None
+
+    main_repo.index.add([python_file])
+    #assert git_utils.changed_python_files_in_tree(main_repo.working_dir) != []
+    main_repo.index.commit("adding python file")
+    assert git_utils.changed_python_files_in_tree(main_repo.working_dir) != [os.path.basename(python_file)]
+
+
 def test_dont_include_scripts_with_extensions(main_repo):
     # type: (repo.Repo) -> None
 

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -211,13 +211,13 @@ def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
 
 
-def test_get_uncommitted_python_files(main_repo, python_file):
+def test_get_staged_python_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
     assert os.path.exists(os.path.join(main_repo.working_dir, os.path.basename(python_file)))
-    assert git_utils.uncommitted_python_files(main_repo.working_dir) == frozenset()
+    assert git_utils.staged_python_files(main_repo.working_dir) == frozenset()
     main_repo.index.add([python_file])
-    assert git_utils.uncommitted_python_files(main_repo.working_dir) == frozenset(['program.py'])
+    assert git_utils.staged_python_files(main_repo.working_dir) == frozenset(['program.py'])
 
 
 def test_dont_include_scripts_with_extensions(main_repo):

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -211,13 +211,32 @@ def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
 
 
-def test_get_staged_python_files(main_repo, python_file):
+def test_getting_staged_python_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
     assert os.path.exists(os.path.join(main_repo.working_dir, os.path.basename(python_file)))
     assert git_utils.staged_python_files(main_repo.working_dir) == []
     main_repo.index.add([python_file])
     assert git_utils.staged_python_files(main_repo.working_dir) == ['program.py']
+
+
+def test_getting_unstaged_python_files(main_repo, python_file):
+    # type: (repo.Repo, str) -> None
+
+    py_file = os.path.join(main_repo.working_dir, os.path.basename(python_file))
+    assert git_utils.unstaged_python_files(main_repo.working_dir) == []
+    assert os.path.exists(py_file)
+    main_repo.index.add([python_file])
+    with open(py_file, 'w') as changed_file:
+        changed_file.write(' ')
+    assert git_utils.unstaged_python_files(main_repo.working_dir) == ['program.py']
+
+
+def test_getting_untracked_python_files(main_repo, python_file):
+    # type: (repo.Repo, str) -> None
+
+    assert os.path.exists(os.path.join(main_repo.working_dir, os.path.basename(python_file)))
+    assert git_utils.untracked_python_files(main_repo.working_dir) == ['program.py']
 
 
 def test_dont_include_scripts_with_extensions(main_repo):

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -215,9 +215,9 @@ def test_get_staged_python_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
     assert os.path.exists(os.path.join(main_repo.working_dir, os.path.basename(python_file)))
-    assert git_utils.staged_python_files(main_repo.working_dir) == frozenset()
+    assert git_utils.staged_python_files(main_repo.working_dir) == []
     main_repo.index.add([python_file])
-    assert git_utils.staged_python_files(main_repo.working_dir) == frozenset(['program.py'])
+    assert git_utils.staged_python_files(main_repo.working_dir) == ['program.py']
 
 
 def test_dont_include_scripts_with_extensions(main_repo):

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -211,7 +211,7 @@ def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
 
 
-def test_uncommitted_files(main_repo, python_file):
+def test_get_uncommitted_python_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
     assert os.path.exists(os.path.join(main_repo.working_dir, os.path.basename(python_file)))

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -211,7 +211,7 @@ def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
     assert git_utils.changed_python_files_in_tree(main_repo.working_dir) == [os.path.basename(python_file)]
 
 
-def test_committed_files(main_repo, python_file):
+def test_uncommitted_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
     assert os.path.exists(os.path.join(main_repo.working_dir, os.path.basename(python_file)))

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -214,10 +214,10 @@ def test_dont_include_uncommited_or_untracked_files(main_repo, python_file):
 def test_committed_files(main_repo, python_file):
     # type: (repo.Repo, str) -> None
 
+    assert os.path.exists(os.path.join(main_repo.working_dir, os.path.basename(python_file)))
+    assert git_utils.uncommitted_python_files(main_repo.working_dir) == frozenset()
     main_repo.index.add([python_file])
-    #assert git_utils.changed_python_files_in_tree(main_repo.working_dir) != []
-    main_repo.index.commit("adding python file")
-    assert git_utils.changed_python_files_in_tree(main_repo.working_dir) != [os.path.basename(python_file)]
+    assert git_utils.uncommitted_python_files(main_repo.working_dir) == frozenset(['program.py'])
 
 
 def test_dont_include_scripts_with_extensions(main_repo):


### PR DESCRIPTION
### Why is this PR necessary?
This PR is intended to allow us to fetch any python files that are uncommitted or untracked. This was brought up while working on https://github.com/Shopify/starscream/pull/37131. While attempting to move the linting to be achieved through a `.py` module we have the ability to use `shopify_python` in order to fetch the changed files to run the linter on. Currently `shopify_python` does not support getting untracked and uncommitted files.

### How does this PR work?
This PR adds two additional methods allowing us to have three methods in total that provide us will all changed python files in a repo. 