### PR TITLE
Added .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.egg-info
 .DS_Store
 .cache
+.idea
 build/
 dist/


### PR DESCRIPTION
### Why is this PR necessary?
`.idea` directory needs to be ignored when pushing to `shopify_python`.

### How does this PR work?
This PR adds `.idea` directory to gitignore which is generated by pycharm config. 