### PR TITLE
Gate typing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest-randomly==1.1.2
 
 mock==2.0.0
 mypy==0.501  ; python_version >= "3.3"
+astroid>=1.6,<=2.0.4

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setuptools.setup(
     test_suite='tests',
     install_requires=[
         'GitPython~=2.1.11',
-        'typing~=3.6.6',
+        'typing~=3.6.6 ; python_version<"3.5"',
         'autopep8~=1.4',
     ],
     extras_require={


### PR DESCRIPTION
The `typing` package became a part of the python library since Python 3.5, but was provisional up until 3.7. This PR gates the `typing` package to only be installed for python versions `< 3.7`.

As an aside, the tests were failing due to a change in an unpinned package dependency `astroid`. This PR also pins the astroid version to the last version that was passing tests.