### PR TITLE
Bump version to 0.5.3

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.5.2'
+__version__ = '0.5.3'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
This bumps the package version to 0.5.3

This version accounts for changes made to the package dependencies which entail:
- gate `typing` package to `python_version < 3.5` to avoid pip installation failures in Python 3.7
- Pin `astroid` version to last version that passed our functional tests.

(https://github.com/Shopify/shopify_python/pull/112)