### PR TITLE
[WIP] bump pylint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     ],
     extras_require={
         ':python_version>="3.0"': [
-            'pylint~=2.1.1'
+            'pylint~=2.1'
         ],
         ':python_version<"3.0"': [
             'pylint~=1.9.3'

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
This module doesn't pass `pytest` on `master`


Problem summary:

Currently [shopify_python requires pylint ~= 2.1.1](https://github.com/Shopify/shopify_python/blob/v0.5.2/setup.py#L46). But, `pylint` v2.1.* has this dependency issue on `'isort >= 4.2.5`. There's no dependency constraint there, so eventually `isort` released `v5`. [pylint 2.1.1 picks up the new version and breaks](https://github.com/PyCQA/isort/issues/1273#issuecomment-654190176).

More recently, `pylint 2.6.0` supports `isort v5` [https://github.com/PyCQA/pylint/pull/3725](https://github.com/PyCQA/pylint/pull/3725)

This PR relaxes the dependency constraint so `shopify_python` will pick up the newer `pylint` version.

This PR fixes #114

I tested this by:
[ ] pytest locally
[ ] push to PyPi test and test fix downstream in Panama CI