### PR TITLE
Swap master for main in git_utils

### DIFF
--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.5.3'
+__version__ = '0.5.4'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None

--- a/shopify_python/git_utils.py
+++ b/shopify_python/git_utils.py
@@ -14,12 +14,12 @@ class GitUtilsException(Exception):
     pass
 
 
-def _remote_origin_master(git_repo):
+def _remote_origin_main(git_repo):
     # type: (repo.Repo) -> head.Head
-    remote_master = git_repo.heads.master.tracking_branch()
-    if not remote_master or not remote_master.is_valid():
-        raise GitUtilsException("Unable to locate remote branch origin/master")
-    return remote_master
+    remote_main = git_repo.heads.main.tracking_branch()
+    if not remote_main or not remote_main.is_valid():
+        raise GitUtilsException("Unable to locate remote branch origin/main")
+    return remote_main
 
 
 def _modified_in_branch(git_repo, other_ref):
@@ -53,8 +53,8 @@ def changed_python_files_in_tree(root_path):
     # type: (str) -> typing.List[str]
 
     git_repo = repo.Repo(root_path)
-    remote_master = _remote_origin_master(git_repo)
-    modified = _modified_in_branch(git_repo, remote_master)
+    remote_main = _remote_origin_main(git_repo)
+    modified = _modified_in_branch(git_repo, remote_main)
     abs_modified = [os.path.join(git_repo.working_dir, x) for x in modified]
     return [mod for (mod, abs_mod) in zip(modified, abs_modified)
             if os.path.exists(abs_mod) and os.path.isfile(abs_mod) and _file_is_python(abs_mod)]

--- a/tests/shopify_python/test_git_utils.py
+++ b/tests/shopify_python/test_git_utils.py
@@ -68,7 +68,7 @@ def main_repo(tmpdir, remote_repo):
     open(str(file_name), 'wb').close()
     new_repo.index.add([str(file_name)])
     new_repo.index.commit("initial commit")
-    new_repo.remote('origin').push('master')
+    new_repo.remote('origin').push('main')
 
     return new_repo
 
@@ -109,18 +109,18 @@ def test_only_include_modified_locally(main_repo, python_file):
         origin = main_repo.remote('origin')
         full_path = os.path.join(main_repo.working_dir, filename)
         open(full_path, 'w').close()
-        remote_master_commit = main_repo.index.commit("adding modified file")
+        remote_main_commit = main_repo.index.commit("adding modified file")
         origin.push()
-        return remote_master_commit
+        return remote_main_commit
 
-    # Add a file and push it to origin/master
+    # Add a file and push it to origin/main
     modified_file_commit = _add_and_commit_file('modified_file.py')
 
-    # Create a new branch from here, but remain on master
+    # Create a new branch from here, but remain on main
     main_repo.create_head('foo')
-    assert main_repo.active_branch.name == 'master'
+    assert main_repo.active_branch.name == 'main'
 
-    # Add another file and push it to origin/master
+    # Add another file and push it to origin/main
     added_file_commit = _add_and_commit_file('added_file.py')
 
     # Checkout 'foo' branch, add, modify, and commit files
@@ -130,14 +130,14 @@ def test_only_include_modified_locally(main_repo, python_file):
     with open(modified_file_path, 'a') as modified_file:
         modified_file.writelines("new line here")
     main_repo.index.add([python_file, modified_file_path])
-    local_master_commit = main_repo.index.commit("adding python file")
+    local_main_commit = main_repo.index.commit("adding python file")
 
-    # current commit should have same parents as remote master (diverged tree)
+    # current commit should have same parents as remote main (diverged tree)
     assert modified_file_commit.parents == [starting_commit]
     assert added_file_commit.parents == [modified_file_commit]
-    assert local_master_commit.parents == [modified_file_commit]
+    assert local_main_commit.parents == [modified_file_commit]
 
-    assert local_master_commit != added_file_commit
+    assert local_main_commit != added_file_commit
 
     # only the one new file is added
     expected = ['modified_file.py', 'program.py']
@@ -151,21 +151,21 @@ def test_cant_find_remote_origin(main_repo, remote_repo):
 
     with pytest.raises(git_utils.GitUtilsException) as ex:
         git_utils.changed_python_files_in_tree(main_repo.working_dir)
-    assert "Unable to locate remote branch origin/master" in ex.exconly()
+    assert "Unable to locate remote branch origin/main" in ex.exconly()
 
 
-def test_cant_find_origin_master(main_repo, remote_repo):
+def test_cant_find_origin_main(main_repo, remote_repo):
     # type: (repo.Repo, repo.Repo) -> None
 
     remote_foo = remote_repo.create_head('foo')
     remote_repo.head.reference = remote_foo
-    remote_repo.delete_head('master')
+    remote_repo.delete_head('main')
 
     main_repo.remotes[0].fetch(prune=True)
 
     with pytest.raises(git_utils.GitUtilsException) as ex:
         git_utils.changed_python_files_in_tree(main_repo.working_dir)
-    assert "Unable to locate remote branch origin/master" in ex.exconly()
+    assert "Unable to locate remote branch origin/main" in ex.exconly()
 
 
 def test_dont_include_deleted_files(main_repo, python_file):
@@ -174,7 +174,7 @@ def test_dont_include_deleted_files(main_repo, python_file):
     origin = main_repo.remote('origin')
     main_repo.index.add([python_file])
     main_repo.index.commit("adding python file")
-    origin.push('master')
+    origin.push('main')
 
     main_repo.create_head('foo').checkout()
     main_repo.index.remove([python_file])


### PR DESCRIPTION
Starscream has updated our default branch name to `main` and we need to be able to find it using the shopify_python git_utils tools used in our push hooks. 

Should I actually be keeping master or is it ok to force an update to main for this version?