### PR TITLE
M1 compatability fixes

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: shopify-python
 type: python
 
 up:
-  - python: 3.6.5
+  - python: 3.9.7
   - python_develop
   - pip: [requirements.txt]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pytest==3.0.6
 pytest-randomly==1.1.2
 
 mock==2.0.0
-mypy==0.501  ; python_version >= "3.3"
+mypy==0.740  ; python_version >= "3.3"
 astroid>=1.6,<=2.0.4

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.5.3'
+__version__ = '0.6.0'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
Bumping shopify_python to 0.6.0

This allows us to build shopify_python on the new M1 Macbooks, and makes it compatible with the other repos that depend on it that are upgrading.

* Bump Python version
* Bumps mypy version

🎩  `dev up` runs successfully on M1 👍 