### PR TITLE
M1 compatibility fixes: bump astroid version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ pytest-randomly==1.1.2
 
 mock==2.0.0
 mypy==0.740  ; python_version >= "3.3"
-astroid>=1.6,<=2.0.4
+astroid<=2.0.4 ; python_version <= "3.0"
+astroid ; python_version >= "3.0"

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
Leaving `astroid` to install an older version for Python 2 but install latest compatible available versions for Python 3.

The reasoning behind this is that pylint needs upgrading for Python 3.9+, which can't be done without updating astroid:
```
┃ The conflict is caused by:
┃     The user requested astroid<=2.1.0 and >=1.6.1
┃     pylint 2.12.2 depends on astroid<2.10 and >=2.9.0
```