### PR TITLE
Pylint version in setup.py for Py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
     ],
     extras_require={
         ':python_version>="3.0"': [
-            'pylint~=2.1.1'
+            'pylint>=2.1.1'
         ],
         ':python_version<"3.0"': [
             'pylint~=1.9.3'

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.6.1'
+__version__ = '0.6.2'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
As a follow up to https://github.com/Shopify/shopify_python/pull/120, we can't install a more recent version of pylint as we specify it in `setup.py` - easy to miss as it's not in the requirements.

Tested by installing the wheel locally in required repo and then installing pylint