### PR TITLE
Bumping gitpython for python3

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ name: shopify-python
 type: python
 
 up:
-  - python: 3.9.7
+  - python: 3.9.8
   - python_develop
   - pip: [requirements.txt]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mock==2.0.0
 mypy==0.740  ; python_version >= "3.3"
 astroid<=2.0.4 ; python_version <= "3.0"
 astroid ; python_version >= "3.0"
+twine # for interacting/uploading to pypi

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setuptools.setup(
     ],
     test_suite='tests',
     install_requires=[
-        'GitPython~=2.1.11',
+        'GitPython~=2.1.11 ; python_version<"3.0"',
+        'GitPython>=3.1.30 ; python_version>="3.0"',
         'typing~=3.6.6 ; python_version<"3.5"',
         'autopep8~=1.4',
     ],

--- a/shopify_python/__init__.py
+++ b/shopify_python/__init__.py
@@ -7,7 +7,7 @@ from shopify_python import google_styleguide
 from shopify_python import shopify_styleguide
 
 
-__version__ = '0.6.2'
+__version__ = '0.6.3'
 
 
 def register(linter):  # type: (lint.PyLinter) -> None


### PR DESCRIPTION
Moving gitpython to 3.1.30 for python 3
also bumping local python from `3.9.7` to `3.9.8` for m1 compat reasons